### PR TITLE
Fix issue #21,support both python 2.7 and python 3.4

### DIFF
--- a/tensorflow_serving/session_bundle/example/export_half_plus_two.py
+++ b/tensorflow_serving/session_bundle/example/export_half_plus_two.py
@@ -26,6 +26,8 @@ Output from this program is typically used to exercise Session
 loading and execution code.
 """
 
+from __future__ import print_function
+
 # This is a placeholder for a Google-internal import.
 
 import tensorflow as tf
@@ -63,7 +65,7 @@ def Export():
     # CopyAssets is used as a callback during export to copy files to the
     # given export directory.
     def CopyAssets(export_path):
-      print "copying asset files to: %s" % export_path
+      print("copying asset files to: %s" % export_path)
 
     # Use a fixed global step number.
     global_step_tensor = tf.Variable(123, name="global_step")

--- a/tensorflow_serving/session_bundle/exporter.py
+++ b/tensorflow_serving/session_bundle/exporter.py
@@ -20,6 +20,7 @@ See: go/tf-exporter
 
 import os
 import re
+import six
 
 import tensorflow as tf
 
@@ -94,7 +95,7 @@ def generic_signature(name_tensor_map):
     A Signature message.
   """
   signature = manifest_pb2.Signature()
-  for name, tensor in name_tensor_map.iteritems():
+  for name, tensor in six.iteritems(name_tensor_map):
     signature.generic_signature.map[name].tensor_name = tensor.name
   return signature
 
@@ -167,7 +168,7 @@ class Exporter(object):
     signatures_proto = manifest_pb2.Signatures()
     if default_graph_signature:
       signatures_proto.default_signature.CopyFrom(default_graph_signature)
-    for signature_name, signature in named_graph_signatures.iteritems():
+    for signature_name, signature in six.iteritems(named_graph_signatures):
       signatures_proto.named_signatures[signature_name].CopyFrom(signature)
     signatures_any_buf = any_pb2.Any()
     signatures_any_buf.Pack(signatures_proto)


### PR DESCRIPTION
Fix issue #21, to make "serving/tensorflow_serving/session_bundle/example/export_half_plus_two.py" and "serving/tensorflow_serving/session_bundle/exporter.py" support both python 2.7 and python 3.4.