### PR TITLE
Add a workspace name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "tf_serving")
+
 local_repository(
   name = "tf",
   path = __workspace_dir__ + "/tensorflow",

--- a/tensorflow_serving/test_util/test_util.cc
+++ b/tensorflow_serving/test_util/test_util.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow_serving/test_util/test_util.h"
 
 #include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
@@ -23,6 +24,15 @@ namespace serving {
 namespace test_util {
 
 string TestSrcDirPath(const string& relative_path) {
+  const string base_path = tensorflow::io::JoinPath(
+      getenv("TEST_SRCDIR"),
+      "tf_serving/tensorflow_serving");
+  if (Env::Default()->FileExists(base_path)) {
+    // Supported in Bazel 0.2.2+.
+    return tensorflow::io::JoinPath(base_path, relative_path);
+  }
+  // Old versions of Bazel sometimes don't include the workspace name in the
+  // runfiles path.
   return tensorflow::io::JoinPath(
       tensorflow::io::JoinPath(getenv("TEST_SRCDIR"),
                                "tensorflow_serving"),


### PR DESCRIPTION
Bazel is going to be restructuring the runfiles tree (see
https://github.com/bazelbuild/bazel/wiki/Updating-the-runfiles-tree-structure
for details), which requires all projects to have a workspace name
(`__main__` will be used if one is not provided).

Feel free to suggest a different name if you guys prefer, but something
needs to be set or the tests will break when Bazel starts using the new
runfiles tree structure.