### PR TITLE
fixed a bit of confusing documentation

### DIFF
--- a/tensorflow_serving/batching/basic_batch_scheduler.h
+++ b/tensorflow_serving/batching/basic_batch_scheduler.h
@@ -155,15 +155,14 @@ class BasicBatchScheduler : public BatchScheduler<TaskType> {
 
     // The number of threads to use to process batches.
     //
-    // This parameter also determines the maximum number of batches worth of
-    // tasks that can be enqueued: If all batch threads are busy, Schedule()
-    // will accept at most 'num_batch_threads' additional batches worth of tasks
-    // before rejecting tasks with an UNAVAILABLE error.
+    // If all threads are busy, Schedule() will enqueue up to 
+    // max_enqueued_batches * max_batch_size individual tasks before throwing
+    // an UNAVAILABLE error.
     //
     // Must be >= 1, and should be tuned carefully.
     int num_batch_threads = 1;
 
-    // The maximum number of batches that can be enqueued (accepted by
+    // The maximum number of enqueued tasks in terms of batches (accepted by
     // Schedule() but not yet being processed on a batch thread). See the
     // class documentation above for guidelines on how to tune this parameter.
     int max_enqueued_batches = 1;

--- a/tensorflow_serving/batching/basic_batch_scheduler.h
+++ b/tensorflow_serving/batching/basic_batch_scheduler.h
@@ -154,7 +154,6 @@ class BasicBatchScheduler : public BatchScheduler<TaskType> {
     string thread_pool_name = {"batch_threads"};
 
     // The number of threads to use to process batches.
-    //
     // Must be >= 1, and should be tuned carefully.
     int num_batch_threads = 1;
 

--- a/tensorflow_serving/batching/basic_batch_scheduler.h
+++ b/tensorflow_serving/batching/basic_batch_scheduler.h
@@ -155,16 +155,14 @@ class BasicBatchScheduler : public BatchScheduler<TaskType> {
 
     // The number of threads to use to process batches.
     //
-    // If all threads are busy, Schedule() will enqueue up to 
-    // max_enqueued_batches * max_batch_size individual tasks before throwing
-    // an UNAVAILABLE error.
-    //
     // Must be >= 1, and should be tuned carefully.
     int num_batch_threads = 1;
 
-    // The maximum number of enqueued tasks in terms of batches (accepted by
-    // Schedule() but not yet being processed on a batch thread). See the
-    // class documentation above for guidelines on how to tune this parameter.
+    // The maximum allowable number of enqueued (accepted by Schedule() but
+    // not yet being processed on a batch thread) tasks in terms of batches.
+    // If this limit is reached, Schedule() will return an UNAVAILABLE error.
+    // See the class documentation above for guidelines on how to tune this
+    // parameter.
     int max_enqueued_batches = 1;
 
     // The following options are typically only overridden by test code.

--- a/tensorflow_serving/batching/shared_batch_scheduler.h
+++ b/tensorflow_serving/batching/shared_batch_scheduler.h
@@ -135,10 +135,12 @@ class SharedBatchScheduler
     // above.)
     int64 batch_timeout_micros = 10 * 1000 /* 10 milliseconds */;
 
-    // The maximum length of the queue, in terms of the number of batches. (A
+    // The maximum length of the queue, in terms of the number of batches (a
     // batch that has been scheduled on a thread is considered to have been
-    // removed from the queue.) See the class documentation above for guidelines
-    // on how to tune this parameter.
+    // removed from the queue). The queue may hold up to 
+    //                max_enqueued_batches * max_batch_size 
+    // individual tasks.See the class documentation above for guidelines on 
+    // how to tune this parameter.
     int max_enqueued_batches = 1;
   };
   Status AddQueue(const QueueOptions& options,

--- a/tensorflow_serving/batching/shared_batch_scheduler.h
+++ b/tensorflow_serving/batching/shared_batch_scheduler.h
@@ -135,12 +135,11 @@ class SharedBatchScheduler
     // above.)
     int64 batch_timeout_micros = 10 * 1000 /* 10 milliseconds */;
 
-    // The maximum length of the queue, in terms of the number of batches (a
-    // batch that has been scheduled on a thread is considered to have been
-    // removed from the queue). The queue may hold up to 
-    //                max_enqueued_batches * max_batch_size 
-    // individual tasks.See the class documentation above for guidelines on 
-    // how to tune this parameter.
+    // The maximum allowable number of enqueued (accepted by Schedule() but
+    // not yet being processed on a batch thread) tasks in terms of batches.
+    // If this limit is reached, Schedule() will return an UNAVAILABLE error.
+    // See the class documentation above for guidelines on how to tune this
+    // parameter.
     int max_enqueued_batches = 1;
   };
   Status AddQueue(const QueueOptions& options,


### PR DESCRIPTION
The documentation incorrectly states that `num_batch_threads` governs the number of batches worth of tasks that may be enqueued. 