### PR TITLE
Increases //tensorflow_serving/core:basic_manager_test test size

### DIFF
--- a/tensorflow_serving/core/BUILD
+++ b/tensorflow_serving/core/BUILD
@@ -454,7 +454,7 @@ cc_library(
 
 cc_test(
     name = "basic_manager_test",
-    size = "small",
+    size = "medium",
     srcs = ["basic_manager_test.cc"],
     deps = [
         "@tf//tensorflow/core:lib",


### PR DESCRIPTION
This test is timeout flaky on ci.bazel.io, see:
  http://ci.bazel.io/job/TensorFlow_Serving/81/BAZEL_VERSION=HEAD,PLATFORM_NAME=linux-x86_64/console
  http://ci.bazel.io/job/TensorFlow_Serving/84/BAZEL_VERSION=HEAD,PLATFORM_NAME=linux-x86_64/console