### PR TITLE
Remaining typo fixes: minist -> mnist

### DIFF
--- a/tensorflow_serving/example/mnist_inference.cc
+++ b/tensorflow_serving/example/mnist_inference.cc
@@ -104,7 +104,7 @@ class MnistServiceImpl final : public MnistService::Service {
 
     // Transform protobuf input to inference input tensor and create
     // output tensor placeholder.
-    // See minist_export.py for details.
+    // See mnist_export.py for details.
     Tensor input(tensorflow::DT_FLOAT, {1, kImageDataSize});
     std::copy_n(request->image_data().begin(), kImageDataSize,
                 input.flat<float>().data());
@@ -125,7 +125,7 @@ class MnistServiceImpl final : public MnistService::Service {
     }
 
     // Transform inference output tensor to protobuf output.
-    // See minist_export.py for details.
+    // See mnist_export.py for details.
     if (outputs.size() != 1) {
       return Status(StatusCode::INTERNAL,
                     tensorflow::strings::StrCat(

--- a/tensorflow_serving/example/mnist_inference_2.cc
+++ b/tensorflow_serving/example/mnist_inference_2.cc
@@ -302,7 +302,7 @@ void MnistServiceImpl::DoClassifyInBatch(
   }
 
   // Transform protobuf input to inference input tensor.
-  // See minist_model.py for details.
+  // See mnist_model.py for details.
   // WARNING(break-tutorial-inline-code): The following code snippet is
   // in-lined in tutorials, please update tutorial documents accordingly
   // whenever code changes.
@@ -342,7 +342,7 @@ void MnistServiceImpl::DoClassifyInBatch(
   }
 
   // Transform inference output tensor to protobuf output.
-  // See minist_model.py for details.
+  // See mnist_model.py for details.
   const auto& scores_mat = scores.matrix<float>();
   for (int i = 0; i < batch_size; ++i) {
     auto calldata = batch->mutable_task(i)->calldata;


### PR DESCRIPTION
I didn't notice these typos when I submitted pull request #73 a few days ago.