### PR TITLE
Remove `grte/v4` from examples

### DIFF
--- a/tensorflow_serving/example/inception_client.py
+++ b/tensorflow_serving/example/inception_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """Send JPEG image to inception_inference server for classification.
 """

--- a/tensorflow_serving/example/inception_client.py
+++ b/tensorflow_serving/example/inception_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/python2.7
+#!/usr/bin/env python
 
 """Send JPEG image to inception_inference server for classification.
 """

--- a/tensorflow_serving/example/inception_client.py
+++ b/tensorflow_serving/example/inception_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/grte/v4/bin/python2.7
+#!/usr/bin/python2.7
 
 """Send JPEG image to inception_inference server for classification.
 """

--- a/tensorflow_serving/example/inception_export.py
+++ b/tensorflow_serving/example/inception_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 """Export inception model given existing training checkpoints.
 """
 

--- a/tensorflow_serving/example/inception_export.py
+++ b/tensorflow_serving/example/inception_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/grte/v4/bin/python2.7
+#!/usr/bin/python2.7
 """Export inception model given existing training checkpoints.
 """
 
@@ -105,7 +105,7 @@ def export():
       class_descriptions.append(texts[s])
     class_tensor = tf.constant(class_descriptions)
 
-    classes = tf.contrib.lookup.index_to_string(tf.to_int64(indices), 
+    classes = tf.contrib.lookup.index_to_string(tf.to_int64(indices),
                                                 mapping=class_tensor)
 
     # Restore variables from training checkpoint.

--- a/tensorflow_serving/example/inception_export.py
+++ b/tensorflow_serving/example/inception_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/python2.7
+#!/usr/bin/env python
 """Export inception model given existing training checkpoints.
 """
 

--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """A client that talks to mnist_inference service.
 

--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/python2.7
+#!/usr/bin/env python
 
 """A client that talks to mnist_inference service.
 

--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/grte/v4/bin/python2.7
+#!/usr/bin/python2.7
 
 """A client that talks to mnist_inference service.
 

--- a/tensorflow_serving/example/mnist_export.py
+++ b/tensorflow_serving/example/mnist_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/grte/v4/bin/python2.7
+#!/usr/bin/python2.7
 """Train and export a simple Softmax Regression TensorFlow model.
 
 The model is from the TensorFlow "MNIST For ML Beginner" tutorial. This program

--- a/tensorflow_serving/example/mnist_export.py
+++ b/tensorflow_serving/example/mnist_export.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/python2.7
+#!/usr/bin/env python
+
 """Train and export a simple Softmax Regression TensorFlow model.
 
 The model is from the TensorFlow "MNIST For ML Beginner" tutorial. This program

--- a/tensorflow_serving/example/mnist_export.py
+++ b/tensorflow_serving/example/mnist_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """Train and export a simple Softmax Regression TensorFlow model.
 

--- a/tensorflow_serving/example/mnist_input_data.py
+++ b/tensorflow_serving/example/mnist_input_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/python2.7
+#!/usr/bin/env python
 
 """Functions for downloading and reading MNIST data."""
 

--- a/tensorflow_serving/example/mnist_input_data.py
+++ b/tensorflow_serving/example/mnist_input_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/grte/v4/bin/python2.7
+#!/usr/bin/python2.7
 
 """Functions for downloading and reading MNIST data."""
 

--- a/tensorflow_serving/example/mnist_input_data.py
+++ b/tensorflow_serving/example/mnist_input_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """Functions for downloading and reading MNIST data."""
 


### PR DESCRIPTION
While going through the examples I came across a few instances of `#!/usr/grte/v4/bin/python2.7`. `grte/v4` is an internal Google tool, right? This pull request sets a standard shebang line.