### PR TITLE
Update Dockerfile.devel

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
         swig \
         zip \
         zlib1g-dev \
+        libcurl3-dev \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
./configure  comes up this error:
Please specify the location of python. [Default is /usr/bin/python]: 
Do you wish to build TensorFlow with Google Cloud Platform support? [y/N] y
Google Cloud Platform support will be enabled for TensorFlow
ERROR: It appears that the development version of libcurl is not available. Please install the libcurl3-dev package.