### PR TITLE
Instead of appending all of each image values, fix it to extend items…

### DIFF
--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -91,8 +91,7 @@ def do_inference(hostport, work_dir, concurrency, num_tests):
   for _ in range(num_tests):
     request = mnist_inference_pb2.MnistRequest()
     image, label = test_data_set.next_batch(1)
-    for pixel in image[0]:
-      request.image_data.append(pixel.item())
+    request.image_data.extend(list(image[0].astype(float)))
     with cv:
       while result['active'] == concurrency:
         cv.wait()


### PR DESCRIPTION
… at once

Where I follow the example codes in mnist_client.py, I found more efficient way to append image data to request.

As fixing code like below, about 2x faster in the loop. (350ms -> 190ms, In the loop that starts from 91th line on the jupyter notebook)

And the user time of entire built source is decreased 4.5 sec to 3.2 sec.

So I suggest fixing it!