### PR TITLE
Address issue with serving build errors on Bazel 0.3.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,4 +11,4 @@ tf_serving_workspace()
 
 # Specify the minimum required bazel version.
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "check_version")
-check_version("0.3.0")
+check_version("0.3.1")

--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -6,7 +6,7 @@ To compile and use TensorFlow Serving, you need to set up some prerequisites.
 
 ### Bazel
 
-TensorFlow Serving requires Bazel 0.3.0 or higher. You can find the Bazel
+TensorFlow Serving requires Bazel 0.3.1 or higher. You can find the Bazel
 installation instructions [here](http://bazel.io/docs/install.html).
 
 If you have the prerequisites for Bazel, those instructions consist of the
@@ -14,13 +14,13 @@ following steps:
 
 1.  Download the relevant binary from
     [here](https://github.com/bazelbuild/bazel/releases).
-    Let's say you downloaded bazel-0.3.0-installer-linux-x86_64.sh. You would
+    Let's say you downloaded bazel-0.3.1-installer-linux-x86_64.sh. You would
     execute:
 
     ~~~shell
     cd ~/Downloads
-    chmod +x bazel-0.3.0-installer-linux-x86_64.sh
-    ./bazel-0.3.0-installer-linux-x86_64.sh --user
+    chmod +x bazel-0.3.1-installer-linux-x86_64.sh
+    ./bazel-0.3.1-installer-linux-x86_64.sh --user
     ~~~
 2.  Set up your environment. Put this in your ~/.bashrc.
 

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -56,7 +56,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
     >>/root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.3.0
+ENV BAZEL_VERSION 0.3.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \


### PR DESCRIPTION
Receiving the following issues when attempting to build `serving@master` with the included Dockerfile:

```
bazel build --ignore_unsupported_sandboxing -c opt tensorflow_serving/...
INFO: Reading 'startup' options from /root/.bazelrc: --batch
ERROR: /root/.cache/bazel/_bazel_root/1b03e6b0b95a8320062041ca0659e00e/external/org_tensorflow/tensorflow/tensorflow.bzl:571:26: Traceback (most recent call last):
        File "/root/.cache/bazel/_bazel_root/1b03e6b0b95a8320062041ca0659e00e/external/org_tensorflow/tensorflow/tensorflow.bzl", line 565
                rule(attrs = {"srcs": attr.label_list..."), <3 more arguments>)}, <2 more arguments>)
        File "/root/.cache/bazel/_bazel_root/1b03e6b0b95a8320062041ca0659e00e/external/org_tensorflow/tensorflow/tensorflow.bzl", line 571, in rule
                attr.label_list(cfg = "data", allow_files = True)
expected ConfigurationTransition or NoneType for 'cfg' while calling label_list but got string instead: data.
ERROR: com.google.devtools.build.lib.packages.BuildFileContainsErrorsException: error loading package '': Extension file 'tensorflow/tensorflow.bzl' has errors.
```

Fixed in 0.3.1: https://github.com/tensorflow/tensorflow/issues/4343, https://github.com/tensorflow/tensorflow/issues/4319