### PR TITLE
Ignore built /bazel-tensorflow_serving file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 /bazel-out
 /bazel-serving
 /bazel-tensorflow
+/bazel-tensorflow_serving
 /bazel-testlogs
 /bazel-tf
 /bazel-workspace


### PR DESCRIPTION
`/bazel-tensorflow_serving` is built and stored in the repository root, this will prevent it from being tracked.