### PR TITLE
Modify server_core visibility for external server components

### DIFF
--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -30,7 +30,7 @@ cc_library(
     srcs = ["server_core.cc"],
     hdrs = ["server_core.h"],
     visibility = [
-        "//tensorflow_serving:internal",
+        "//visibility:public",
     ],
     deps = [
         "//tensorflow_serving/apis:model_proto",

--- a/tensorflow_serving/servables/tensorflow/BUILD
+++ b/tensorflow_serving/servables/tensorflow/BUILD
@@ -199,6 +199,9 @@ cc_library(
     name = "serving_session",
     srcs = ["serving_session.cc"],
     hdrs = ["serving_session.h"],
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         "@org_tensorflow//tensorflow/core:core_cpu",
         "@org_tensorflow//tensorflow/core:lib",
@@ -211,6 +214,9 @@ cc_library(
     name = "predict_impl",
     srcs = ["predict_impl.cc"],
     hdrs = ["predict_impl.h"],
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         "//tensorflow_serving/apis:predict_proto",
         "//tensorflow_serving/core:servable_handle",

--- a/tensorflow_serving/servables/tensorflow/BUILD
+++ b/tensorflow_serving/servables/tensorflow/BUILD
@@ -199,9 +199,6 @@ cc_library(
     name = "serving_session",
     srcs = ["serving_session.cc"],
     hdrs = ["serving_session.h"],
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         "@org_tensorflow//tensorflow/core:core_cpu",
         "@org_tensorflow//tensorflow/core:lib",
@@ -214,9 +211,6 @@ cc_library(
     name = "predict_impl",
     srcs = ["predict_impl.cc"],
     hdrs = ["predict_impl.h"],
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         "//tensorflow_serving/apis:predict_proto",
         "//tensorflow_serving/core:servable_handle",


### PR DESCRIPTION
Update visibility on `server_core`, `serving_session` and `predict_impl` to aid in building a custom server outside of the tensorflow_serving package.

Example directory structure:
```
tensorflow_serving/...
tensorflow/...
tf_models/...
promiseofcake/server/server.cc
```

@chrisolston, would all of these declarations be valid, or is `PredictionService` more of an internal definition?

Based upon discussion here: https://github.com/tensorflow/serving/issues/121, https://github.com/tensorflow/serving/issues/121#issuecomment-250011716