### PR TITLE
Fixes #201 - Update inception_k8s.json config

### DIFF
--- a/tensorflow_serving/example/inception_k8s.json
+++ b/tensorflow_serving/example/inception_k8s.json
@@ -25,7 +25,7 @@
               "-c"
             ],
             "args": [
-              "/serving/bazel-bin/tensorflow_serving/example/inception_inference --port=9000 /serving/inception-export"
+              "/serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server --port=9000 --model_name=inception --model_base_path=/serving/inception-export"
             ],
             "ports": [
               {


### PR DESCRIPTION
Existing example file points to a now non-existent 'inception_inference' file. This points now to the tensorflow_model_server.