### PR TITLE
add command line option for file system poll wait (seconds)

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -185,13 +185,13 @@ int main(int argc, char** argv) {
   tensorflow::int32 port = 8500;
   bool enable_batching = false;
   tensorflow::string model_name = "default";
-  tensorflow::int32 file_system_polling_interval = -1;
+  tensorflow::int32 file_system_poll_wait_seconds = 1;
   tensorflow::string model_base_path;
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("port", &port, "port to listen on"),
       tensorflow::Flag("enable_batching", &enable_batching, "enable batching"),
       tensorflow::Flag("model_name", &model_name, "name of model"),
-      tensorflow::Flag("file_system_polling_interval", &file_system_polling_interval, "interval in seconds between each poll of the file system for new model"),
+      tensorflow::Flag("file_system_poll_wait_seconds", &file_system_poll_wait_seconds, "interval in seconds between each poll of the file system for new model version"),
       tensorflow::Flag("model_base_path", &model_base_path,
                        "path to export (required)")};
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
@@ -220,11 +220,7 @@ int main(int argc, char** argv) {
   ServerCoreConfig core_config;
   core_config.aspired_version_policy =
       std::unique_ptr<AspiredVersionPolicy>(new EagerLoadPolicy);
-
-  // Override default file polling interval
-  if (file_system_polling_interval > 0) {
-    core_config.file_system_poll_wait_seconds = file_system_polling_interval;
-  }
+  core_config.file_system_poll_wait_seconds = file_system_poll_wait_seconds;
 
   std::unique_ptr<ServerCore> core;
   TF_CHECK_OK(ServerCore::Create(

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -185,11 +185,13 @@ int main(int argc, char** argv) {
   tensorflow::int32 port = 8500;
   bool enable_batching = false;
   tensorflow::string model_name = "default";
+  tensorflow::int32 file_system_polling_interval = -1;
   tensorflow::string model_base_path;
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("port", &port, "port to listen on"),
       tensorflow::Flag("enable_batching", &enable_batching, "enable batching"),
       tensorflow::Flag("model_name", &model_name, "name of model"),
+      tensorflow::Flag("file_system_polling_interval", &file_system_polling_interval, "interval in seconds between each poll of the file system for new model"),
       tensorflow::Flag("model_base_path", &model_base_path,
                        "path to export (required)")};
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
@@ -218,6 +220,11 @@ int main(int argc, char** argv) {
   ServerCoreConfig core_config;
   core_config.aspired_version_policy =
       std::unique_ptr<AspiredVersionPolicy>(new EagerLoadPolicy);
+
+  // Override default file polling interval
+  if (file_system_polling_interval > 0) {
+    core_config.file_system_poll_wait_seconds = file_system_polling_interval;
+  }
 
   std::unique_ptr<ServerCore> core;
   TF_CHECK_OK(ServerCore::Create(

--- a/tensorflow_serving/model_servers/tensorflow_model_server_test.py
+++ b/tensorflow_serving/model_servers/tensorflow_model_server_test.py
@@ -68,14 +68,13 @@ class TensorflowModelServerTest(tf.test.TestCase):
     if self.server_proc is not None:
       self.server_proc.terminate()
 
-  def RunServer(self, port, model_name, model_path, file_system_polling_interval):
+  def RunServer(self, port, model_name, model_path):
     """Run tensorflow_model_server using test config."""
     print 'Starting test server...'
     command = os.path.join(self.binary_dir, 'tensorflow_model_server')
     command += ' --port=' + str(port)
     command += ' --model_name=' + model_name
     command += ' --model_base_path=' + model_path
-    command += ' --file_system_polling_interval=' + file_system_polling_interval
     command += ' --alsologtostderr'
     print command
     self.server_proc = subprocess.Popen(shlex.split(command))
@@ -110,7 +109,7 @@ class TensorflowModelServerTest(tf.test.TestCase):
     atexit.register(self.TerminateProcs)
     model_server_address = self.RunServer(
         PickUnusedPort(), 'default',
-        os.path.join(self.testdata_dir, 'half_plus_two'), 1)
+        os.path.join(self.testdata_dir, 'half_plus_two'))
     time.sleep(5)
     self.VerifyPredictRequest(model_server_address)
     self.VerifyPredictRequest(model_server_address, specify_output=False)
@@ -120,7 +119,7 @@ class TensorflowModelServerTest(tf.test.TestCase):
     atexit.register(self.TerminateProcs)
     model_server_address = self.RunServer(
         PickUnusedPort(), 'default',
-        os.path.join(self.testdata_dir, 'bad_half_plus_two'), 1)
+        os.path.join(self.testdata_dir, 'bad_half_plus_two'))
     time.sleep(5)
     with self.assertRaises(face.AbortionError) as error:
       self.VerifyPredictRequest(model_server_address)

--- a/tensorflow_serving/model_servers/tensorflow_model_server_test.py
+++ b/tensorflow_serving/model_servers/tensorflow_model_server_test.py
@@ -68,13 +68,14 @@ class TensorflowModelServerTest(tf.test.TestCase):
     if self.server_proc is not None:
       self.server_proc.terminate()
 
-  def RunServer(self, port, model_name, model_path):
+  def RunServer(self, port, model_name, model_path, file_system_polling_interval):
     """Run tensorflow_model_server using test config."""
     print 'Starting test server...'
     command = os.path.join(self.binary_dir, 'tensorflow_model_server')
     command += ' --port=' + str(port)
     command += ' --model_name=' + model_name
     command += ' --model_base_path=' + model_path
+    command += ' --file_system_polling_interval=' + file_system_polling_interval
     command += ' --alsologtostderr'
     print command
     self.server_proc = subprocess.Popen(shlex.split(command))
@@ -109,7 +110,7 @@ class TensorflowModelServerTest(tf.test.TestCase):
     atexit.register(self.TerminateProcs)
     model_server_address = self.RunServer(
         PickUnusedPort(), 'default',
-        os.path.join(self.testdata_dir, 'half_plus_two'))
+        os.path.join(self.testdata_dir, 'half_plus_two'), 1)
     time.sleep(5)
     self.VerifyPredictRequest(model_server_address)
     self.VerifyPredictRequest(model_server_address, specify_output=False)
@@ -119,7 +120,7 @@ class TensorflowModelServerTest(tf.test.TestCase):
     atexit.register(self.TerminateProcs)
     model_server_address = self.RunServer(
         PickUnusedPort(), 'default',
-        os.path.join(self.testdata_dir, 'bad_half_plus_two'))
+        os.path.join(self.testdata_dir, 'bad_half_plus_two'), 1)
     time.sleep(5)
     with self.assertRaises(face.AbortionError) as error:
       self.VerifyPredictRequest(model_server_address)


### PR DESCRIPTION
Add an option on the command line for changing the default 30s file system poll wait interval.
