### PR TITLE
aspire all model versions in the model base path

### DIFF
--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -136,6 +136,67 @@ Status PollFileSystemForServable(
   return Status::OK();
 }
 
+Status PollFileSystemForAllServables(
+    const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
+    std::vector<ServableData<StoragePath>>* versions) {
+  // First, determine whether the base path exists. This check guarantees that
+  // we don't emit an empty aspired-versions list for a non-existent (or
+  // transiently unavailable) base-path. (On some platforms, GetChildren()
+  // returns an empty list instead of erring if the base path isn't found.)
+  if (!Env::Default()->FileExists(servable.base_path())) {
+    return errors::InvalidArgument("Could not find base path ",
+                                   servable.base_path(), " for servable ",
+                                   servable.servable_name());
+  }
+
+  // Retrieve a list of base-path children from the file system.
+  std::vector<string> children;
+  TF_RETURN_IF_ERROR(
+      Env::Default()->GetChildren(servable.base_path(), &children));
+
+  // GetChildren() returns all descendants instead for cloud storage like GCS.
+  // In such case we should filter out all non-direct descendants.
+  std::set<string> real_children;
+  for (int i = 0; i < children.size(); ++i) {
+    const string& child = children[i];
+    real_children.insert(child.substr(0, child.find_first_of('/')));
+  }
+  children.clear();
+  children.insert(children.begin(), real_children.begin(), real_children.end());
+
+  // Identify the all the versions, among children that can be interpreted as
+  // version numbers.
+  int latest_version_child = -1;
+  int64 latest_version;
+  bool model_aspired = false;
+
+  for (int i = 0; i < children.size(); ++i) {
+    const string& child = children[i];
+    int64 child_version_num;
+    if (!strings::safe_strto64(child.c_str(), &child_version_num)) {
+      continue;
+    }
+
+    latest_version_child = i;
+    latest_version = child_version_num;
+    // Emit the aspired-versions data.
+    if (latest_version_child >= 0) {
+      const ServableId servable_id = {servable.servable_name(), latest_version};
+      const string full_path =
+          io::JoinPath(servable.base_path(), children[latest_version_child]);
+      versions->emplace_back(ServableData<StoragePath>(servable_id, full_path));
+      model_aspired = true;
+    }
+  }
+
+  if (!model_aspired) {
+    LOG(WARNING) << "No versions of servable " << servable.servable_name()
+                 << " found under base path " << servable.base_path();
+  }
+
+  return Status::OK();
+}
+
 // Polls the file system, and populates 'versions_by_servable_name' with the
 // aspired-versions data FileSystemStoragePathSource should emit based on what
 // was found, indexed by servable name.
@@ -146,7 +207,7 @@ Status PollFileSystemForConfig(
   for (const FileSystemStoragePathSourceConfig::ServableToMonitor& servable :
        config.servables()) {
     std::vector<ServableData<StoragePath>> versions;
-    TF_RETURN_IF_ERROR(PollFileSystemForServable(servable, &versions));
+    TF_RETURN_IF_ERROR(PollFileSystemForAllServables(servable, &versions));
     versions_by_servable_name->insert(
         {servable.servable_name(), std::move(versions)});
   }


### PR DESCRIPTION
Serve all the versions of models available on the `model_base_path`