### PR TITLE
Add options to serve multiple versions of model

### DIFF
--- a/tensorflow_serving/g3doc/serving_advanced.md
+++ b/tensorflow_serving/g3doc/serving_advanced.md
@@ -142,9 +142,8 @@ With all these, `ServerCore` internally does the following:
   `AspiredVersionsManager` that manages all such `Loader` instances created by
   the `SessionBundleSourceAdapter`.
 
-Whenever a new version is available, this `AspiredVersionsManager` always
-unloads the old version and replaces it with the new one. If you want to
-start customizing, you are encouraged to understand the components that it
+Whenever a new version is available, this `AspiredVersionsManager` loads the new version, and, 
+under its default behavior, unloads the old one. If you want to start customizing, you are encouraged to understand the components that it
 creates internally, and how to configure them.
 
 It is worth mentioning that TensorFlow Serving is designed from scratch to be

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -76,6 +76,84 @@ std::set<string> GetDeletedServables(
   return deleted_servables;
 }
 
+//Add a new ServableData for the model version to the the vector of versions to aspire
+void AspireVersion(
+    const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
+    const string& version_relative_path,
+    const int version_number,
+    std::vector<ServableData<StoragePath>>* versions) {
+    const ServableId servable_id = {servable.servable_name(), version_number};
+    const string full_path =
+        io::JoinPath(servable.base_path(), version_relative_path);
+    versions->emplace_back(ServableData<StoragePath>(servable_id, full_path));
+}
+
+// Attempts to parse the version path as integer, upon success writes the result to 'version_number' and returns true.
+// Otherwise returns false when fail to parse the version path.
+bool ParseVersionNumber(const string& version_path, int64 *version_number) {
+  return strings::safe_strto64(version_path.c_str(), version_number);
+}
+
+// Update the servable data to include
+// all the model versions found in the base path as aspired versions.
+// The argument 'children' represents a list of base-path children from the file system.
+// Returns true if valid servable path is found, otherwise returns false.
+bool AspireAllVersions(
+    const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
+    const std::vector<string>& children,   // represents a list of base-path children from the file system.
+    std::vector<ServableData<StoragePath>>* versions) {
+
+  bool version_found = false;
+  for (const string& child : children) {
+    // Identify all the versions, among children that can be interpreted as
+    // version numbers.
+    int64 version_number;
+    if (ParseVersionNumber(child, &version_number)) {
+      // Emit all the aspired-versions data.
+      AspireVersion(servable, child, version_number, versions);
+      version_found = true;
+    }
+  }
+
+  return version_found;
+}
+
+// Update the servable data to include
+// the latest version found in the base path as aspired version.
+// The argument 'children' represents a list of base-path children from the file system.
+// Returns true if valid servable path is found, otherwise returns false.
+bool AspireLatestVersions(
+    const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
+    const std::vector<string>& children,
+    std::vector<ServableData<StoragePath>>* versions) {
+
+  // Identify the latest version, among children that can be interpreted as
+  // version numbers.
+  int latest_version_child_index;
+  int64 latest_version_number;
+  bool version_found = false;
+  for (int i = 0; i < children.size(); ++i) {
+    int64 version_number;
+    if (!ParseVersionNumber(children[i], &version_number)) {
+      continue;
+    }
+
+    // Check if this is the largest version number
+    if (!version_found || latest_version_number < version_number) {
+      latest_version_child_index = i;
+      latest_version_number = version_number;
+    }
+    version_found = true;
+  }
+
+  // Emit the latest aspired version.
+  if (version_found) {
+    AspireVersion(servable, children[latest_version_child_index], latest_version_number, versions);
+  }
+
+  return version_found;
+}
+
 // Like PollFileSystemForConfig(), but for a single servable.
 Status PollFileSystemForServable(
     const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
@@ -105,30 +183,17 @@ Status PollFileSystemForServable(
   children.clear();
   children.insert(children.begin(), real_children.begin(), real_children.end());
 
-  // Identify the latest version, among children that can be interpreted as
-  // version numbers.
-  int latest_version_child = -1;
-  int64 latest_version;
-  for (int i = 0; i < children.size(); ++i) {
-    const string& child = children[i];
-    int64 child_version_num;
-    if (!strings::safe_strto64(child.c_str(), &child_version_num)) {
-      continue;
-    }
-
-    if (latest_version_child < 0 || latest_version < child_version_num) {
-      latest_version_child = i;
-      latest_version = child_version_num;
-    }
+  bool version_found = false;
+  switch (servable.version_policy()) {
+    case FileSystemStoragePathSourceConfig::LATEST_VERSION:
+      version_found = AspireLatestVersions(servable, children, versions);
+      break;
+    case FileSystemStoragePathSourceConfig::ALL_VERSIONS:
+      version_found = AspireAllVersions(servable, children, versions);
+      break;
   }
 
-  // Emit the aspired-versions data.
-  if (latest_version_child >= 0) {
-    const ServableId servable_id = {servable.servable_name(), latest_version};
-    const string full_path =
-        io::JoinPath(servable.base_path(), children[latest_version_child]);
-    versions->emplace_back(ServableData<StoragePath>(servable_id, full_path));
-  } else {
+  if (!version_found) {
     LOG(WARNING) << "No versions of servable " << servable.servable_name()
                  << " found under base path " << servable.base_path();
   }

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.proto
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.proto
@@ -4,6 +4,17 @@ package tensorflow.serving;
 
 // Config proto for FileSystemStoragePathSource.
 message FileSystemStoragePathSourceConfig {
+
+  // The policy to define how many versions of the servable should be
+  // served at the same time.
+  enum VersionPolicy {
+    // Only serve the latest version that exists in the base path.
+    // This is the default behavior.
+    LATEST_VERSION = 0;
+    // Serves all the versions that exist in the base path.
+    ALL_VERSIONS = 1;
+  }
+
   // A servable name and base path to look for versions of the servable.
   message ServableToMonitor {
     // The servable name to supply in aspired-versions callback calls. Child
@@ -12,6 +23,10 @@ message FileSystemStoragePathSourceConfig {
 
     // The path to monitor, i.e. look for child paths of the form base_path/123.
     string base_path = 2;
+
+    // The policy to determines the number of versions of the servable to be served at the same time.
+    VersionPolicy version_policy = 3;
+
   };
 
   // The servables to monitor for new versions, and aspire.

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
@@ -179,7 +179,6 @@ TEST(FileSystemStoragePathSourceTest, MultipleVersionsAtTheSameTime) {
   TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "42")));
   TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "17")));
 
-  string all_version_policy = std::to_string(FileSystemStoragePathSourceConfig::ALL_VERSIONS);
   auto config = test_util::CreateProto<FileSystemStoragePathSourceConfig>(
       strings::Printf("servables: { "
                       "  version_policy: ALL_VERSIONS "


### PR DESCRIPTION
Modify `FileSystemStoragePathSource` to emit all versions rather than just the latest version if the following environment variable is set `TF_SERVING_MULTIPLE_VERSIONS` is set to true.

This does not change the default behavior of only serving the latest version.

This is discussed in the following Github issue :
https://github.com/tensorflow/serving/issues/197
