### PR TITLE
Switch replication controller to deployment

### DIFF
--- a/tensorflow_serving/example/inception_k8s.json
+++ b/tensorflow_serving/example/inception_k8s.json
@@ -1,61 +1,36 @@
-{
-  "apiVersion": "v1",
-  "kind": "ReplicationController",
-  "metadata": {
-    "name": "inception-controller"
-  },
-  "spec": {
-    "replicas": 3,
-    "selector": {
-      "worker": "inception-pod"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "worker": "inception-pod"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "name": "inception-container",
-            "image": "gcr.io/tensorflow-serving/inception",
-            "command": [
-              "/bin/sh",
-              "-c"
-            ],
-            "args": [
-              "/serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server --port=9000 --model_name=inception --model_base_path=/serving/inception-export"
-            ],
-            "ports": [
-              {
-                "containerPort": 9000
-              }
-            ]
-          }
-        ],
-        "restartPolicy": "Always"
-      }
-    }
-  }
-}
-
-{
-  "kind": "Service",
-  "apiVersion": "v1",
-  "metadata": {
-    "name": "inception-service"
-  },
-  "spec": {
-    "ports": [
-      {
-        "port": 9000,
-        "targetPort": 9000
-      }
-    ],
-    "selector": {
-      "worker": "inception-pod"
-    },
-    "type": "LoadBalancer"
-  }
-}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: inception-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: inception-server
+    spec:
+      containers:
+      - name: inception-container
+        image: gcr.io/tensorflow-serving/inception:0.2.0
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - /serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server
+          --port=9000 --model_name=inception --model_base_path=/serving/inception-export
+        ports:
+        - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: inception-service
+  name: inception-service
+spec:
+  ports:
+  - port: 9000
+    targetPort: 9000
+  selector:
+    run: inception-service
+  type: LoadBalancer


### PR DESCRIPTION
- Switches out replication controller in favor of deployment 
- Switches out JSON kubernetes configuration format in favor of YAML
- Fixes broken links in tutorial markdown
- Fixes broken arguments in kubernetes config
- Updates tutorial markdown 
