### PR TITLE
add flag for multiple version on command line

### DIFF
--- a/tensorflow_serving/config/BUILD
+++ b/tensorflow_serving/config/BUILD
@@ -28,5 +28,6 @@ serving_proto_library(
     cc_api_version = 2,
     deps = [
         "@protobuf//:cc_wkt_protos",
+        "//tensorflow_serving/sources/storage_path:file_system_storage_path_source_proto",
     ],
 )

--- a/tensorflow_serving/config/model_server_config.proto
+++ b/tensorflow_serving/config/model_server_config.proto
@@ -4,6 +4,7 @@ package tensorflow.serving;
 option cc_enable_arenas = true;
 
 import "google/protobuf/any.proto";
+import "tensorflow_serving/sources/storage_path/file_system_storage_path_source.proto";
 
 // The type of model.
 // TODO(b/31336131): DEPRECATED.
@@ -29,6 +30,10 @@ message ModelConfig {
 
   // Type of model (e.g. "tensorflow").
   string model_platform = 4;
+
+  // Version policy for the model indicating how many versions of the model to be served at the same time.
+  // The default option is to serve only the latest version of the model.
+  FileSystemStoragePathSourceConfig.VersionPolicy version_policy = 5;
 }
 
 // Static list of models to be loaded for serving.

--- a/tensorflow_serving/model_servers/server_core.cc
+++ b/tensorflow_serving/model_servers/server_core.cc
@@ -292,6 +292,7 @@ FileSystemStoragePathSourceConfig ServerCore::CreateStoragePathSourceConfig(
         source_config.add_servables();
     servable->set_servable_name(model.name());
     servable->set_base_path(model.base_path());
+    servable->set_version_policy(model.version_policy());
   }
   return source_config;
 }


### PR DESCRIPTION
Add flag to model_server to enable serving of multiple versions of models (https://github.com/tensorflow/serving/pull/217).

