### PR TITLE
Upgrade Bazel to 0.3.2, required for building TensorFlow.

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -56,7 +56,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
     >>/root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.3.1
+ENV BAZEL_VERSION 0.3.2
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \


### PR DESCRIPTION
The `DockerFile` for building quick a TensorFlow Serving environment is outdated by recent changes in TensorFlow. Basel 0.3.2 or above is required for building.

This commit just bumps the Bazel version in the DockerFile.