### PR TITLE
Switch the tag from 0.2.0 to latest.

### DIFF
--- a/tensorflow_serving/example/inception_k8s.yaml
+++ b/tensorflow_serving/example/inception_k8s.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: inception-container
-        image: gcr.io/tensorflow-serving/inception:0.2.0
+        image: gcr.io/tensorflow-serving/inception
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
I tried to follow the inception_serving tutorial, but got:
```
inception-deployment-3636006731-233j2   0/1       ErrImagePull   0          7s
```
after creating the deployment and service. I checked to see if the specified image:
`gcr.io/tensorflow-serving/inception:0.2.0` exists with:
```shell
$ gcloud beta container images list-tags gcr.io/tensorflow-serving/inception
DIGEST        TAGS    TIMESTAMP            GIT_SHA  VULNERABILITIES  FROM  BUILD
b60c79ea19c6  latest  2016-03-21T16:14:30
```

and saw that there is only one published tag, `latest`.
