### PR TITLE
Fix integer overflow in version number

### DIFF
--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -80,7 +80,7 @@ std::set<string> GetDeletedServables(
 // aspire.
 void AspireVersion(
     const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
-    const string& version_relative_path, const int version_number,
+    const string& version_relative_path, const int64 version_number,
     std::vector<ServableData<StoragePath>>* versions) {
   const ServableId servable_id = {servable.servable_name(), version_number};
   const string full_path =


### PR DESCRIPTION
Hi! 👋 

I'm using the new `export_savedmodel` API to export my tf.contrib.learn model to what is called a *saved model*. In contrast to the normal `export` method it creates a directory that is named by the current timestamp (millisecond precision) instead of the global step. When the model server converts the directory name to the version number for the servable an integer overflow occurs and causes the following error:

```
I tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc:324] File-system polling update: Servable:{name: nubbel version: -627989529}; Servable path: /data/exports/nubbel/1481135727591; Polling frequency: 100
I tensorflow_serving/core/basic_manager.cc:653] Successfully reserved resources to load servable {name: nubbel version: -627989529}
I tensorflow_serving/core/loader_harness.cc:74] Approving load for servable version {name: nubbel version: -627989529}
I tensorflow_serving/core/loader_harness.cc:89] Loading servable version {name: nubbel version: -627989529}
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:192] Loading SavedModel from: /data/exports/nubbel/1481135727591
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:112] Restoring SavedModel bundle.
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:146] Running LegacyInitOp on SavedModel bundle.
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:236] Loading SavedModel: success. Took 94867 microseconds.
I tensorflow_serving/core/loader_harness.cc:122] Successfully loaded servable version {name: nubbel version: -627989529}
F ./tensorflow_serving/core/manager.h:112] Check failed: id.version >= 0 (-627989529 vs. 0)
Aborted
```
As a result the server crashes.

This PR fixes this error by replacing `int` with `int64` which is consistent with all other usages of the version number. The model is then loaded as expected:
```
I tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc:324] File-system polling update: Servable:{name: nubbel version: 1481135727591}; Servable path: /data/exports/nubbel/1481135727591; Polling frequency: 100
I tensorflow_serving/core/basic_manager.cc:653] Successfully reserved resources to load servable {name: nubbel version: 1481135727591}
I tensorflow_serving/core/loader_harness.cc:74] Approving load for servable version {name: nubbel version: 1481135727591}
I tensorflow_serving/core/loader_harness.cc:89] Loading servable version {name: nubbel version: 1481135727591}
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:192] Loading SavedModel from: /data/exports/nubbel/1481135727591
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:112] Restoring SavedModel bundle.
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:146] Running LegacyInitOp on SavedModel bundle.
I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:236] Loading SavedModel: success. Took 118719 microseconds.
I tensorflow_serving/core/loader_harness.cc:122] Successfully loaded servable version {name: nubbel version: 1481135727591}
I tensorflow_serving/core/basic_manager.cc:46] Creating InlineExecutor for BasicManager.
I tensorflow_serving/model_servers/main.cc:203] Running ModelServer at 0.0.0.0:9000 ...
```