### PR TITLE
Raise gRPC max message size from 4M to 100M

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -200,7 +200,8 @@ void RunServer(int port, std::unique_ptr<ServerCore> core,
   std::shared_ptr<grpc::ServerCredentials> creds = InsecureServerCredentials();
   builder.AddListeningPort(server_address, creds);
   builder.RegisterService(&service);
-  builder.SetMaxMessageSize(tensorflow::kint32max);
+  // Raise max frame size for larger request if it is reasonable
+  builder.SetMaxMessageSize(104857600);
   std::unique_ptr<Server> server(builder.BuildAndStart());
   LOG(INFO) << "Running ModelServer at " << server_address << " ...";
   server->Wait();


### PR DESCRIPTION
Resolve https://github.com/tensorflow/serving/issues/288