### PR TITLE
Adds public visibility to predict_impl cc_library

### DIFF
--- a/tensorflow_serving/servables/tensorflow/BUILD
+++ b/tensorflow_serving/servables/tensorflow/BUILD
@@ -400,6 +400,9 @@ cc_library(
     name = "predict_impl",
     srcs = ["predict_impl.cc"],
     hdrs = ["predict_impl.h"],
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         ":get_model_metadata_impl",
         "//tensorflow_serving/apis:get_model_metadata_proto",


### PR DESCRIPTION
I'm trying to use serving as a submodule. When building it complained that //tensorflow_serving/servables/tensorflow:predict_impl was not visible. I've added the public visibility to it.

I hope this is ok.