### PR TITLE
Install grpcio from pypi.python.org and require minimum version 1.1.3

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -32,10 +32,6 @@ RUN pip install enum34 futures mock six && \
     pip install --pre 'protobuf>=3.0.0a3' && \
     pip install 'grpcio>=1.1.3'
 
-
-
-
-
 # Set up Bazel.
 
 # We need to add a custom PPA to pick up JDK8, since trusty doesn't

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -30,7 +30,11 @@ RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
 
 RUN pip install enum34 futures mock six && \
     pip install --pre 'protobuf>=3.0.0a3' && \
-    pip install -i https://testpypi.python.org/simple --pre grpcio
+    pip install 'grpcio>=1.1.3'
+
+
+
+
 
 # Set up Bazel.
 


### PR DESCRIPTION
Addresses tf_serving issue #122 - the mnist example causes a grpc error when run within a Docker container.

Summary:
 - grpcio 0.15 causes a grpc error in the mnist_client.py example
 - https://testpypi.python.org/simple/grpcio does not feature the latest grpcio releases. 

Example:

Server:
```
$> docker run -p 127.0.0.1:9000:9000 -v /host/path/to/exported/models:/models --name=tensorflow_container -it $USER/tensorflow-serving-devel
# clone, configure, test TF in the running container https://tensorflow.github.io/serving/docker
[..]
# start server
$> bazel build //tensorflow_serving/model_servers:tensorflow_model_server
$> bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server --port=9000 --model_name=mnist --model_base_path=/models/mnist_model/
```

Client:
```
$> docker exec -it tensorflow_container bash
$> bazel-bin/tensorflow_serving/example/mnist_client --num_tests=1000 --server=localhost:9000
Successfully downloaded train-images-idx3-ubyte.gz 9912422 bytes.
Extracting /tmp/train-images-idx3-ubyte.gz
Successfully downloaded train-labels-idx1-ubyte.gz 28881 bytes.
Extracting /tmp/train-labels-idx1-ubyte.gz
Successfully downloaded t10k-images-idx3-ubyte.gz 1648877 bytes.
Extracting /tmp/t10k-images-idx3-ubyte.gz
Successfully downloaded t10k-labels-idx1-ubyte.gz 4542 bytes.
Extracting /tmp/t10k-labels-idx1-ubyte.gz
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Inference error rate: 10.4%
```