### PR TITLE
Fix issue with inception_saved_model build - issue 354 - v2

### DIFF
--- a/tensorflow_serving/example/BUILD
+++ b/tensorflow_serving/example/BUILD
@@ -80,7 +80,7 @@ py_binary(
         "inception_export.py",
     ],
     deps = [
-        "@inception//inception",
+        "@inception_model//inception",
         "@org_tensorflow//tensorflow:tensorflow_py",
         "@org_tensorflow//tensorflow/contrib/session_bundle:exporter",
     ],
@@ -92,7 +92,7 @@ py_binary(
         "inception_saved_model.py",
     ],
     deps = [
-        "@inception//inception",
+        "@inception_model//inception",
         "@org_tensorflow//tensorflow:tensorflow_py",
         "@org_tensorflow//tensorflow/python/saved_model:builder",
         "@org_tensorflow//tensorflow/python/saved_model:constants",

--- a/tensorflow_serving/workspace.bzl
+++ b/tensorflow_serving/workspace.bzl
@@ -7,9 +7,10 @@ load('@org_tensorflow//tensorflow:workspace.bzl', 'tf_workspace')
 # workspace_dir is the absolute path to the TensorFlow Serving repo. If linked
 # as a submodule, it'll likely be '__workspace_dir__ + "/serving"'
 def tf_serving_workspace():
-  native.local_repository(
-    name = "inception",
+  native.new_local_repository(
+    name = "inception_model",
     path = "tf_models/inception",
+    build_file = "tf_models/inception/inception/BUILD",
   )
 
   tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")


### PR DESCRIPTION
 Tensorflow-serving issue 354: [https://github.com/tensorflow/serving/issues/354](https://github.com/tensorflow/serving/issues/354)

When the inception repository name is the same as the inception model workspace name this results in anomalous behavior of tensorflow_serving/example build. 
Running the command 
```
bazel-bin/tensorflow_serving/example/inception_saved_model --checkpoint_dir=inception-v3 --output_dir=inception-export
```
fails because a needed support module cannot be loaded.

When the repository name is different than the workspace, a build time warning is generated.

This pull request provides a way to have the repository name be different than the inception workspace name (allowing the examples' build to work) and correct for the build time workspace/repository name mismatch warning.

This is similar to the solution suggested in [https://github.com/bazelbuild/bazel/issues/1331](https://github.com/bazelbuild/bazel/issues/1331)
