### PR TITLE
Remove deprecated calls and upgrade them to newer ones in examples

### DIFF
--- a/tensorflow_serving/example/inception_export.py
+++ b/tensorflow_serving/example/inception_export.py
@@ -90,8 +90,8 @@ def export():
       class_descriptions.append(texts[s])
     class_tensor = tf.constant(class_descriptions)
 
-    classes = tf.contrib.lookup.index_to_string(tf.to_int64(indices),
-                                                mapping=class_tensor)
+    table = tf.contrib.lookup.index_to_string_table_from_tensor(class_tensor)
+    classes = table.lookup(tf.to_int64(indices))
 
     # Restore variables from training checkpoint.
     variable_averages = tf.train.ExponentialMovingAverage(
@@ -114,7 +114,7 @@ def export():
         return
 
       # Export inference model.
-      init_op = tf.group(tf.initialize_all_tables(), name='init_op')
+      init_op = tf.group(tf.tables_initializer(), name='init_op')
       classification_signature = exporter.classification_signature(
           input_tensor=serialized_tf_example,
           classes_tensor=classes,

--- a/tensorflow_serving/example/inception_saved_model.py
+++ b/tensorflow_serving/example/inception_saved_model.py
@@ -94,8 +94,8 @@ def export():
       class_descriptions.append(texts[s])
     class_tensor = tf.constant(class_descriptions)
 
-    classes = tf.contrib.lookup.index_to_string(
-        tf.to_int64(indices), mapping=class_tensor)
+    table = tf.contrib.lookup.index_to_string_table_from_tensor(class_tensor)
+    classes = table.lookup(tf.to_int64(indices))
 
     # Restore variables from training checkpoint.
     variable_averages = tf.train.ExponentialMovingAverage(
@@ -152,7 +152,7 @@ def export():
           method_name=signature_constants.PREDICT_METHOD_NAME)
 
       legacy_init_op = tf.group(
-          tf.initialize_all_tables(), name='legacy_init_op')
+          tf.tables_initializer(), name='legacy_init_op')
       builder.add_meta_graph_and_variables(
           sess, [tag_constants.SERVING],
           signature_def_map={

--- a/tensorflow_serving/example/mnist_export.py
+++ b/tensorflow_serving/example/mnist_export.py
@@ -68,13 +68,14 @@ def main(_):
   y_ = tf.placeholder('float', shape=[None, 10])
   w = tf.Variable(tf.zeros([784, 10]))
   b = tf.Variable(tf.zeros([10]))
-  sess.run(tf.initialize_all_variables())
+  sess.run(tf.global_variables_initializer())
   y = tf.nn.softmax(tf.matmul(x, w) + b, name='y')
   cross_entropy = -tf.reduce_sum(y_ * tf.log(y))
   train_step = tf.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
   values, indices = tf.nn.top_k(y, 10)
-  prediction_classes = tf.contrib.lookup.index_to_string(
-      tf.to_int64(indices), mapping=tf.constant([str(i) for i in range(10)]))
+  table = tf.contrib.lookup.index_to_string_table_from_tensor(
+    tf.constant([str(i) for i in range(10)]))
+  prediction_classes = table.lookup(tf.to_int64(indices))
   for _ in range(FLAGS.training_iteration):
     batch = mnist.train.next_batch(50)
     train_step.run(feed_dict={x: batch[0], y_: batch[1]})
@@ -92,7 +93,7 @@ def main(_):
   # whenever code changes.
   export_path = sys.argv[-1]
   print('Exporting trained model to %s' % export_path)
-  init_op = tf.group(tf.initialize_all_tables(), name='init_op')
+  init_op = tf.group(tf.tables_initializer(), name='init_op')
   saver = tf.train.Saver(sharded=True)
   model_exporter = exporter.Exporter(saver)
   model_exporter.init(

--- a/tensorflow_serving/example/mnist_saved_model.py
+++ b/tensorflow_serving/example/mnist_saved_model.py
@@ -69,13 +69,14 @@ def main(_):
   y_ = tf.placeholder('float', shape=[None, 10])
   w = tf.Variable(tf.zeros([784, 10]))
   b = tf.Variable(tf.zeros([10]))
-  sess.run(tf.initialize_all_variables())
+  sess.run(tf.global_variables_initializer())
   y = tf.nn.softmax(tf.matmul(x, w) + b, name='y')
   cross_entropy = -tf.reduce_sum(y_ * tf.log(y))
   train_step = tf.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
   values, indices = tf.nn.top_k(y, 10)
-  prediction_classes = tf.contrib.lookup.index_to_string(
-      tf.to_int64(indices), mapping=tf.constant([str(i) for i in xrange(10)]))
+  table = tf.contrib.lookup.index_to_string_table_from_tensor(
+    tf.constant([str(i) for i in xrange(10)]))
+  prediction_classes = table.lookup(tf.to_int64(indices))
   for _ in range(FLAGS.training_iteration):
     batch = mnist.train.next_batch(50)
     train_step.run(feed_dict={x: batch[0], y_: batch[1]})
@@ -120,7 +121,7 @@ def main(_):
       outputs={'scores': tensor_info_y},
       method_name=signature_constants.PREDICT_METHOD_NAME)
 
-  legacy_init_op = tf.group(tf.initialize_all_tables(), name='legacy_init_op')
+  legacy_init_op = tf.group(tf.tables_initializer(), name='legacy_init_op')
   builder.add_meta_graph_and_variables(
       sess, [tag_constants.SERVING],
       signature_def_map={

--- a/tensorflow_serving/servables/tensorflow/testdata/export_bad_half_plus_two.py
+++ b/tensorflow_serving/servables/tensorflow/testdata/export_bad_half_plus_two.py
@@ -42,7 +42,7 @@ def Export():
     # Note that the model is intentionally exported without using exporter,
     # but using the same format. This is to avoid exporter creating default
     # empty signatures upon export.
-    tf.initialize_all_variables().run()
+    tf.global_variables_initializer().run()
     saver = tf.train.Saver()
     saver.export_meta_graph(
         filename=os.path.join(export_path, "export.meta"))

--- a/tensorflow_serving/servables/tensorflow/testdata/export_half_plus_two.py
+++ b/tensorflow_serving/servables/tensorflow/testdata/export_half_plus_two.py
@@ -41,7 +41,7 @@ def Export():
     y = tf.add(tf.multiply(a, x), b)
 
     # Run an export.
-    tf.initialize_all_variables().run()
+    tf.global_variables_initializer().run()
     export = exporter.Exporter(tf.train.Saver())
     export.init(named_graph_signatures={
         "inputs": exporter.generic_signature({"x": x}),


### PR DESCRIPTION
Switch deprecated calls to newer functions:

- `tf.contrib.lookup.index_to_string` to `tf.contrib.lookup.index_to_string_table_from_tensor`
- `tf.initialize_all_tables` to `tf.tables_initializer`
- `tf.initialize_all_variables` to `tf.global_variables_initializer`