### PR TITLE
Add hdfs_file_system in BUILD file

### DIFF
--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -132,6 +132,7 @@ cc_binary(
         "@protobuf//:cc_wkt_protos",
         "@org_tensorflow//tensorflow/core:lib",
         "@org_tensorflow//tensorflow/core/platform/cloud:gcs_file_system",
+        "@org_tensorflow//tensorflow/core/platform/hadoop:hadoop_file_system",
         "//tensorflow_serving/apis:prediction_service_proto",
         "//tensorflow_serving/config:model_server_config_proto",
         "//tensorflow_serving/core:availability_preserving_policy",


### PR DESCRIPTION
Related to https://github.com/tensorflow/serving/issues/359 .

Now we can export and load the models from HDFS instead of local file system or Google Storage with this change.

Hope it can be merged.