### PR TITLE
UPD inception_k8s.yaml with coherent metadata / selector

### DIFF
--- a/tensorflow_serving/example/inception_k8s.yaml
+++ b/tensorflow_serving/example/inception_k8s.yaml
@@ -40,12 +40,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    run: inception-service
+    app: inception-service
   name: inception-service
 spec:
   ports:
   - port: 9000
     targetPort: 9000
   selector:
-    run: inception-service
+    app: inception-service
   type: LoadBalancer


### PR DESCRIPTION
Deployment and Service definition use different keys, so that service exposition failed (No pods associated with inception-service).