### PR TITLE
Add locate to installed packages in Dockerfile 

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libpng12-dev \
         libzmq3-dev \
-        locate \
+        mlocate \
         pkg-config \
         python-dev \
         python-numpy \

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libpng12-dev \
         libzmq3-dev \
+        locate \
         pkg-config \
         python-dev \
         python-numpy \


### PR DESCRIPTION
Add locate to installed packages in Dockerfile to support locate command in tensorflow configure script.

Following the [instructions](https://tensorflow.github.io/serving/docker) for configuring tensorflow serving in the docker container, the configure script errors out at line 254 when attempting to run the "locate" command. This is recent code that was committed in [this commit](https://github.com/tensorflow/tensorflow/commit/27dd167c5fd4d0d4e7572cc8d639c0e61e69215e)

Installing the locate package via the Dockerfile solves this issue. 