### PR TITLE
Add build for CPU

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -44,4 +44,17 @@ RUN mkdir /bazel && \
     cd / && \
     rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
+# Download TensorFlow Serving
+RUN git clone --recurse-submodules https://github.com/tensorflow/serving && \
+  cd serving && \
+  git checkout
+
+WORKDIR /serving/tensorflow
+RUN tensorflow/tools/ci_build/builds/configured CPU
+
+WORKDIR /serving
+RUN bazel build -c opt tensorflow_serving/... && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/local/bin/ && \
+    bazel clean --expunge
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
When building serving with [docker file](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.devel), I noticed only bazel is built but not serving binary. So I add this piece to the docker file. Please review.