### PR TITLE
Add srcs_version = "PY2AND3" in BUILD files

### DIFF
--- a/tensorflow_serving/apis/BUILD
+++ b/tensorflow_serving/apis/BUILD
@@ -126,6 +126,7 @@ serving_proto_library(
 py_library(
     name = "prediction_service_proto_py_pb2",
     srcs = ["prediction_service_pb2.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":classification_proto_py_pb2",
         ":get_model_metadata_proto_py_pb2",

--- a/tensorflow_serving/example/BUILD
+++ b/tensorflow_serving/example/BUILD
@@ -22,6 +22,7 @@ filegroup(
 
 py_library(
     name = "mnist_input_data",
+    srcs_version = "PY2AND3",
     srcs = ["mnist_input_data.py"],
 )
 
@@ -32,6 +33,7 @@ py_binary(
     srcs = [
         "mnist_export.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         ":mnist_input_data",
         "@org_tensorflow//tensorflow:tensorflow_py",
@@ -44,6 +46,7 @@ py_binary(
     srcs = [
         "mnist_saved_model.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         ":mnist_input_data",
         "@org_tensorflow//tensorflow:tensorflow_py",
@@ -55,6 +58,7 @@ py_binary(
     srcs = [
         "mnist_client.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         ":mnist_input_data",
         "//tensorflow_serving/apis:predict_proto_py_pb2",
@@ -70,6 +74,7 @@ py_binary(
     srcs = [
         "inception_export.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         "@inception_model//inception",
         "@org_tensorflow//tensorflow:tensorflow_py",
@@ -82,6 +87,7 @@ py_binary(
     srcs = [
         "inception_saved_model.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         "@inception_model//inception",
         "@org_tensorflow//tensorflow:tensorflow_py",
@@ -93,6 +99,7 @@ py_binary(
     srcs = [
         "inception_client.py",
     ],
+    srcs_version = "PY2AND3",
     deps = [
         "//tensorflow_serving/apis:predict_proto_py_pb2",
         "//tensorflow_serving/apis:prediction_service_proto_py_pb2",

--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -169,6 +169,7 @@ py_test(
 py_binary(
     name = "tensorflow_model_server_test_client",
     srcs = ["tensorflow_model_server_test_client.py"],
+    srcs_version = "PY2AND3",
     deps = [
         "//tensorflow_serving/apis:prediction_service_proto_py_pb2",
         "@org_tensorflow//tensorflow:tensorflow_py",

--- a/tensorflow_serving/servables/tensorflow/testdata/BUILD
+++ b/tensorflow_serving/servables/tensorflow/testdata/BUILD
@@ -25,6 +25,7 @@ filegroup(
 
 py_binary(
     name = "export_half_plus_two",
+    srcs_version = "PY2AND3",
     srcs = [
         "export_half_plus_two.py",
     ],
@@ -36,6 +37,7 @@ py_binary(
 
 py_binary(
     name = "export_bad_half_plus_two",
+    srcs_version = "PY2AND3",
     srcs = [
         "export_bad_half_plus_two.py",
     ],


### PR DESCRIPTION
Hi all~

I've used tf to train my model with Anaconda3 (python 3.6), and I want to deploy it using this tf-serving.
But when I build it with ```--force_python=py3 ```, it seems some examples are missing the ```srcs_version = "PY2AND3"``` annotation in BUILD files.

I've succeeded in building tf-serving and runing with python 3.6 after adding these annotations.
