### PR TITLE
add wget to list of apps to be installed

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
         libcurl3-dev \
         openjdk-8-jdk\
         openjdk-8-jre-headless \
+        wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The imagenet training script uses wget to download datasets and fails since it cannot find wget command in the docker container. Hence adding wget to the list would solve it.