### PR TITLE
Working GPU docker: Nvidia driver 384.81;Cuda8 CuDNN6 bazel 5.4

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -20,9 +20,11 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py
+RUN apt-get install python-pip python-dev build-essential 
+
+#RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+#    python get-pip.py && \
+#    rm get-pip.py
 
 # Set up grpc
 
@@ -54,7 +56,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
     >>/root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.4.5
+ENV BAZEL_VERSION 0.5.4
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \
@@ -85,14 +87,6 @@ RUN mkdir /usr/lib/x86_64-linux-gnu/include/ && \
   ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so && \
   ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.6 /usr/local/cuda/lib64/libcudnn.so.6
 
-# Fix from https://github.com/tensorflow/serving/issues/327#issuecomment-282207825
-WORKDIR /
-RUN git clone https://github.com/NVIDIA/nccl.git && \
-    cd nccl/ && \
-    make CUDA_HOME=/usr/local/cuda && \
-    make install && \
-    mkdir -p /usr/local/include/external/nccl_archive/src && \
-    ln -s /usr/local/include/nccl.h /usr/local/include/external/nccl_archive/src/nccl.h
 
 # Configure Tensorflow to use the GPU
 WORKDIR /serving/tensorflow


### PR DESCRIPTION
This docker was built and tested today with the following:
 
Nvidia driver 384.81. Cuda8; Cudnn6; K80 GPUs.

Nvidia docker:
wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker-1.0.1-1.x86_64.rpm
sudo rpm -i /tmp/nvidia-docker*.rpm && rm /tmp/nvidia-docker*.rpm
sudo systemctl start nvidia-docker



