### PR TITLE
use bazel 0.5.4 in Dockerfile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,4 +25,4 @@ tf_serving_workspace()
 # Specify the minimum required bazel version.
 load("@org_tensorflow//tensorflow:workspace.bzl", "check_version")
 
-check_version("0.4.5")
+check_version("0.5.4")

--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -6,7 +6,7 @@ To compile and use TensorFlow Serving, you need to set up some prerequisites.
 
 ### Bazel (only if compiling source code)
 
-TensorFlow Serving requires Bazel 0.4.5 or higher. You can find the Bazel
+TensorFlow Serving requires Bazel 0.5.4 or higher. You can find the Bazel
 installation instructions [here](http://bazel.build/docs/install.html).
 
 If you have the prerequisites for Bazel, those instructions consist of the
@@ -14,13 +14,13 @@ following steps:
 
 1.  Download the relevant binary from
     [here](https://github.com/bazelbuild/bazel/releases).
-    Let's say you downloaded bazel-0.4.5-installer-linux-x86_64.sh. You would
+    Let's say you downloaded bazel-0.5.4-installer-linux-x86_64.sh. You would
     execute:
 
     <pre>
     cd ~/Downloads
-    chmod +x bazel-0.4.5-installer-linux-x86_64.sh
-    ./bazel-0.4.5-installer-linux-x86_64.sh --user
+    chmod +x bazel-0.5.4-installer-linux-x86_64.sh
+    ./bazel-0.5.4-installer-linux-x86_64.sh --user
     </pre>
 
 2.  Set up your environment. Put this in your ~/.bashrc.

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -34,7 +34,7 @@ RUN pip install mock grpcio
 
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.5.1
+ENV BAZEL_VERSION 0.5.4
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -54,7 +54,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
     >>/root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.4.5
+ENV BAZEL_VERSION 0.5.4
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \


### PR DESCRIPTION
The bazel build step requires a minimum bazel version of `0.5.4`. The Dockerfile currently uses bazel `0.5.1` (which is too low). I've tested locally on my Macbook Pro - build ok with bazel `0.5.4` docker container.

To replicate test [follow instruction at](https://github.com/Atlas7/How-to-Deploy-a-Tensorflow-Model-in-Production/blob/mymaster/demo.ipynb) - but with bazel version `0.5.4`.