### PR TITLE
add flag to config per_process_gpu_memory_fraction

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -76,6 +76,7 @@ limitations under the License.
 #include "tensorflow_serving/servables/tensorflow/multi_inference.h"
 #include "tensorflow_serving/servables/tensorflow/predict_impl.h"
 #include "tensorflow_serving/servables/tensorflow/regression_service.h"
+#include "tensorflow_serving/servables/tensorflow/session_bundle_config.pb.h"
 
 namespace grpc {
 class ServerCompletionQueue;
@@ -302,6 +303,7 @@ tensorflow::serving::PlatformConfigMap ParsePlatformConfigMap(
 int main(int argc, char** argv) {
   tensorflow::int32 port = 8500;
   bool enable_batching = false;
+  tensorflow::int32 per_process_gpu_memory_fraction = 100;
   tensorflow::string batching_parameters_file;
   tensorflow::string model_name = "default";
   tensorflow::int32 file_system_poll_wait_seconds = 1;
@@ -346,7 +348,10 @@ int main(int argc, char** argv) {
                        "If non-empty, read an ascii PlatformConfigMap protobuf "
                        "from the supplied file name, and use that platform "
                        "config instead of the Tensorflow platform. (If used, "
-                       "--enable_batching is ignored.)")};
+                       "--enable_batching is ignored.)"),
+      tensorflow::Flag("per_process_gpu_memory_fraction", &per_process_gpu_memory_fraction,
+                       "per_process_gpu_memory_fraction in percent")};
+
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
   const bool parse_result = tensorflow::Flags::Parse(&argc, argv, flag_list);
   if (!parse_result || (model_base_path.empty() && model_config_file.empty())) {
@@ -390,6 +395,14 @@ int main(int argc, char** argv) {
              "--enable_batching";
     }
 
+    //tensorflow::ConfigProto* session_config = session_bundle_config.mutable_session_config();
+    //tensorflow::GPUOptions* gpu_options = session_config->mutable_gpu_options();
+    //gpu_options->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction/100.);
+
+
+    session_bundle_config.mutable_session_config()
+        ->mutable_gpu_options()
+        ->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction/100.);
     session_bundle_config.mutable_session_config()
         ->set_intra_op_parallelism_threads(tensorflow_session_parallelism);
     session_bundle_config.mutable_session_config()

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -351,7 +351,7 @@ int main(int argc, char** argv) {
                        "--enable_batching is ignored.)"),
       tensorflow::Flag("per_process_gpu_memory_fraction", &per_process_gpu_memory_fraction,
                        "Fraction that each process occupies gpu memory space "
-                       "the value is between 0. and 1.0 "
+                       "the value is between 0.0 and 1.0 (with 0.0 as the default) "
                        "If 1.0, the server will allocate all the memory when the server starts, "
                        "If 0.0, Tensorflow will automatically select a value.")};
 

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -303,7 +303,7 @@ tensorflow::serving::PlatformConfigMap ParsePlatformConfigMap(
 int main(int argc, char** argv) {
   tensorflow::int32 port = 8500;
   bool enable_batching = false;
-  tensorflow::int32 per_process_gpu_memory_fraction = 100;
+  float per_process_gpu_memory_fraction = 0.;
   tensorflow::string batching_parameters_file;
   tensorflow::string model_name = "default";
   tensorflow::int32 file_system_poll_wait_seconds = 1;
@@ -350,7 +350,10 @@ int main(int argc, char** argv) {
                        "config instead of the Tensorflow platform. (If used, "
                        "--enable_batching is ignored.)"),
       tensorflow::Flag("per_process_gpu_memory_fraction", &per_process_gpu_memory_fraction,
-                       "per_process_gpu_memory_fraction in percent")};
+                       "Fraction that each process occupies gpu memory space "
+                       "the value is between 0. and 1.0 "
+                       "If 1.0, the server will allocate all the memory when the server starts, "
+                       "If 0.0, Tensorflow will automatically select a value.")};
 
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
   const bool parse_result = tensorflow::Flags::Parse(&argc, argv, flag_list);
@@ -402,7 +405,7 @@ int main(int argc, char** argv) {
 
     session_bundle_config.mutable_session_config()
         ->mutable_gpu_options()
-        ->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction/100.);
+        ->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction);
     session_bundle_config.mutable_session_config()
         ->set_intra_op_parallelism_threads(tensorflow_session_parallelism);
     session_bundle_config.mutable_session_config()

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -398,11 +398,6 @@ int main(int argc, char** argv) {
              "--enable_batching";
     }
 
-    //tensorflow::ConfigProto* session_config = session_bundle_config.mutable_session_config();
-    //tensorflow::GPUOptions* gpu_options = session_config->mutable_gpu_options();
-    //gpu_options->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction/100.);
-
-
     session_bundle_config.mutable_session_config()
         ->mutable_gpu_options()
         ->set_per_process_gpu_memory_fraction(per_process_gpu_memory_fraction);


### PR DESCRIPTION
With "per_process_gpu_memory_fraction" flag (1-100), the users can config per_process_gpu_memory_fraction, otherwise the server process will occupy all the gpu memory.