### PR TITLE
Use print function for python3 compatibility.

### DIFF
--- a/tensorflow_serving/example/inception_saved_model.py
+++ b/tensorflow_serving/example/inception_saved_model.py
@@ -20,6 +20,8 @@ The model is exported as SavedModel with proper signatures that can be loaded by
 standard tensorflow_model_server.
 """
 
+from __future__ import print_function
+
 import os.path
 
 # This is a placeholder for a Google-internal import.
@@ -105,17 +107,17 @@ def export():
         #   /my-favorite-path/imagenet_train/model.ckpt-0,
         # extract global_step from it.
         global_step = ckpt.model_checkpoint_path.split('/')[-1].split('-')[-1]
-        print 'Successfully loaded model from %s at step=%s.' % (
-            ckpt.model_checkpoint_path, global_step)
+        print('Successfully loaded model from %s at step=%s.' % (
+            ckpt.model_checkpoint_path, global_step))
       else:
-        print 'No checkpoint file found at %s' % FLAGS.checkpoint_dir
+        print('No checkpoint file found at %s' % FLAGS.checkpoint_dir)
         return
 
       # Export inference model.
       output_path = os.path.join(
           tf.compat.as_bytes(FLAGS.output_dir),
           tf.compat.as_bytes(str(FLAGS.model_version)))
-      print 'Exporting trained model to', output_path
+      print('Exporting trained model to', output_path)
       builder = tf.saved_model.builder.SavedModelBuilder(output_path)
 
       # Build the signature_def_map.
@@ -165,7 +167,7 @@ def export():
           legacy_init_op=legacy_init_op)
 
       builder.save()
-      print 'Successfully exported model to %s' % FLAGS.output_dir
+      print('Successfully exported model to %s' % FLAGS.output_dir)
 
 
 def preprocess_image(image_buffer):

--- a/tensorflow_serving/example/mnist_saved_model.py
+++ b/tensorflow_serving/example/mnist_saved_model.py
@@ -25,6 +25,8 @@ Usage: mnist_saved_model.py [--training_iteration=x] [--model_version=y] \
     export_dir
 """
 
+from __future__ import print_function
+
 import os
 import sys
 
@@ -47,14 +49,14 @@ def main(_):
           '[--model_version=y] export_dir')
     sys.exit(-1)
   if FLAGS.training_iteration <= 0:
-    print 'Please specify a positive value for training iteration.'
+    print('Please specify a positive value for training iteration.')
     sys.exit(-1)
   if FLAGS.model_version <= 0:
-    print 'Please specify a positive value for version number.'
+    print('Please specify a positive value for version number.')
     sys.exit(-1)
 
   # Train model
-  print 'Training model...'
+  print('Training model...')
   mnist = mnist_input_data.read_data_sets(FLAGS.work_dir, one_hot=True)
   sess = tf.InteractiveSession()
   serialized_tf_example = tf.placeholder(tf.string, name='tf_example')
@@ -77,10 +79,10 @@ def main(_):
     train_step.run(feed_dict={x: batch[0], y_: batch[1]})
   correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
   accuracy = tf.reduce_mean(tf.cast(correct_prediction, 'float'))
-  print 'training accuracy %g' % sess.run(
+  print('training accuracy %g' % sess.run(
       accuracy, feed_dict={x: mnist.test.images,
-                           y_: mnist.test.labels})
-  print 'Done training!'
+                           y_: mnist.test.labels}))
+  print('Done training!')
 
   # Export model
   # WARNING(break-tutorial-inline-code): The following code snippet is
@@ -90,7 +92,7 @@ def main(_):
   export_path = os.path.join(
       tf.compat.as_bytes(export_path_base),
       tf.compat.as_bytes(str(FLAGS.model_version)))
-  print 'Exporting trained model to', export_path
+  print('Exporting trained model to', export_path)
   builder = tf.saved_model.builder.SavedModelBuilder(export_path)
 
   # Build the signature_def_map.
@@ -136,7 +138,7 @@ def main(_):
 
   builder.save()
 
-  print 'Done exporting!'
+  print('Done exporting!')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the examples compatible with python3 (and matches the client code in this directory, which already uses `print_function`).