### PR TITLE
Clarify that the API works in Python 3.

### DIFF
--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -72,7 +72,12 @@ the `tensorflow-serving-api` PIP package using:
 pip install tensorflow-serving-api
 ```
 
-Note: The TensorFlow Serving Python API only supports Python 2.7. It does not support Python 3.
+Note: The TensorFlow Serving Python API
+[is only published for Python 2](https://pypi.python.org/pypi/tensorflow-serving-api/1.0.0),
+but will work for Python 3 if you either build it yourself, or download the Python 2 version,
+unzip it, and copy it into your Python 3 path. There was
+[an issue tracking publishing the API as Python 3](https://github.com/tensorflow/serving/issues/700),
+but it was closed.
 
 ## Installing using apt-get
 

--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -73,11 +73,11 @@ pip install tensorflow-serving-api
 ```
 
 Note: The TensorFlow Serving Python API
-[is only published for Python 2](https://pypi.python.org/pypi/tensorflow-serving-api/1.0.0),
-but will work for Python 3 if you either build it yourself, or download the Python 2 version,
-unzip it, and copy it into your Python 3 path. There was
-[an issue tracking publishing the API as Python 3](https://github.com/tensorflow/serving/issues/700),
-but it was closed.
+[is only published for Python 2](https://pypi.python.org/pypi/tensorflow-serving-api),
+but will work for Python 3 if you either build it yourself, or download the
+Python 2 version, unzip it, and copy it into your Python 3 path. There is a
+[feature request](https://github.com/tensorflow/serving/issues/700) to publish
+the Python 3 package as well.
 
 ## Installing using apt-get
 


### PR DESCRIPTION
Also add a passive-aggressive link to the closed issue.

Slightly tongue-in-cheek, but issue #700 really should be reopened.