### PR TITLE
Add possibility to specify grpc channel args

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -265,7 +265,7 @@ class PredictionServiceImpl final : public PredictionService::Service {
 };
 
 void RunServer(int port, std::unique_ptr<ServerCore> core,
-               bool use_saved_model) {
+               bool use_saved_model, string channel_arguments_str) {
   // "0.0.0.0" is the way to listen on localhost in gRPC.
   const string server_address = "0.0.0.0:" + std::to_string(port);
   tensorflow::serving::ModelServiceImpl model_service(core.get());
@@ -276,6 +276,17 @@ void RunServer(int port, std::unique_ptr<ServerCore> core,
   builder.RegisterService(&model_service);
   builder.RegisterService(&prediction_service);
   builder.SetMaxMessageSize(tensorflow::kint32max);
+  const std::vector<string> channel_arguments =
+      tensorflow::str_util::Split(channel_arguments_str, ",");
+  for (const string& channel_argument : channel_arguments) {
+    const std::vector<string> key_val =
+        tensorflow::str_util::Split(channel_argument, "=");
+    try { // Attempt to add as int, otherwise assume string.
+      builder.AddChannelArgument(key_val[0], std::stoi(key_val[1]));
+    } catch (const std::invalid_argument& e) {
+      builder.AddChannelArgument(key_val[0], key_val[1]);
+    }
+  }
   std::unique_ptr<Server> server(builder.BuildAndStart());
   LOG(INFO) << "Running ModelServer at " << server_address << " ...";
   server->Wait();
@@ -307,6 +318,7 @@ int main(int argc, char** argv) {
   tensorflow::int64 tensorflow_session_parallelism = 0;
   string platform_config_file = "";
   string model_config_file;
+  string grpc_channel_arguments = "";
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("port", &port, "port to listen on"),
       tensorflow::Flag("enable_batching", &enable_batching, "enable batching"),
@@ -358,7 +370,12 @@ int main(int argc, char** argv) {
           "starts, If 0.0, Tensorflow will automatically select a value."),
       tensorflow::Flag("saved_model_tags", &saved_model_tags,
                        "Comma-separated set of tags corresponding to the meta "
-                       "graph def to load from SavedModel.")};
+                       "graph def to load from SavedModel."),
+      tensorflow::Flag(
+                       "grpc_channel_arguments", &grpc_channel_arguments,
+                       "A comma separated list of arguments to be passed to "
+                       "the grpc server. (e.g. "
+                       "grpc.max_connection_age_ms=2000)")};
 
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
   const bool parse_result = tensorflow::Flags::Parse(&argc, argv, flag_list);
@@ -430,7 +447,7 @@ int main(int argc, char** argv) {
 
   std::unique_ptr<ServerCore> core;
   TF_CHECK_OK(ServerCore::Create(std::move(options), &core));
-  RunServer(port, std::move(core), use_saved_model);
+  RunServer(port, std::move(core), use_saved_model, grpc_channel_arguments);
 
   return 0;
 }

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -270,7 +270,8 @@ struct ChannelArgument {
   string value;
 };
 
-// Parses a comma separated list of gRPC channel arguments into list of pairs.
+// Parses a comma separated list of gRPC channel arguments into list of
+// ChannelArgument.
 std::vector<ChannelArgument> parseChannelArgs(
     const string& channel_arguments_str) {
   const std::vector<string> channel_arguments =

--- a/tensorflow_serving/model_servers/tensorflow_model_server_test.py
+++ b/tensorflow_serving/model_servers/tensorflow_model_server_test.py
@@ -122,8 +122,8 @@ class TensorflowModelServerTest(tf.test.TestCase):
                 model_name,
                 model_path,
                 batching_parameters_file='',
-                wait_for_server_ready=True,
-                grpc_channel_arguments=''):
+                grpc_channel_arguments='',
+                wait_for_server_ready=True):
     """Run tensorflow_model_server using test config."""
     print 'Starting test server...'
     command = os.path.join(self.binary_dir, 'tensorflow_model_server')

--- a/tensorflow_serving/model_servers/tensorflow_model_server_test.py
+++ b/tensorflow_serving/model_servers/tensorflow_model_server_test.py
@@ -122,7 +122,8 @@ class TensorflowModelServerTest(tf.test.TestCase):
                 model_name,
                 model_path,
                 batching_parameters_file='',
-                wait_for_server_ready=True):
+                wait_for_server_ready=True,
+                grpc_channel_arguments=''):
     """Run tensorflow_model_server using test config."""
     print 'Starting test server...'
     command = os.path.join(self.binary_dir, 'tensorflow_model_server')
@@ -132,6 +133,8 @@ class TensorflowModelServerTest(tf.test.TestCase):
     if batching_parameters_file:
       command += ' --enable_batching'
       command += ' --batching_parameters_file=' + batching_parameters_file
+    if grpc_channel_arguments:
+      command += ' --grpc_channel_arguments=' + grpc_channel_arguments
     print command
     self.server_proc = subprocess.Popen(shlex.split(command))
     print 'Server started'
@@ -481,6 +484,19 @@ class TensorflowModelServerTest(tf.test.TestCase):
     self.assertNotEqual(self.server_proc.stderr, None)
     self.assertGreater(self.server_proc.stderr.read().find(error_message), -1)
 
+  def testGoodGrpcChannelArgs(self):
+    """Test server starts with grpc_channel_arguments specified."""
+    atexit.register(self.TerminateProcs)
+    model_server_address = self.RunServer(
+      PickUnusedPort(),
+      'default',
+      self._GetSavedModelBundlePath(),
+      grpc_channel_arguments=
+      'grpc.max_connection_age_ms=2000,grpc.lb_policy_name=grpclb'
+    )
+    self.VerifyPredictRequest(model_server_address, expected_output=3.0,
+        specify_output=False, expected_version=self._GetModelVersion(
+            self._GetSavedModelHalfPlusThreePath()))
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
This change makes it possible to pass channel arguments to gRPC when starting the model server.

With this change we can get the behaviour we need when using an L4 load balancer in front of an auto scaling group in AWS.