### PR TITLE
add meta model proto files to pip package

### DIFF
--- a/tensorflow_serving/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_serving/tools/pip_package/build_pip_package.sh
@@ -39,7 +39,10 @@ function main() {
   cp bazel-genfiles/tensorflow_serving/apis/*_pb2.py \
     "${TMPDIR}/tensorflow_serving/apis"
 
-  cp bazel-serving/tensorflow_serving/apis/prediction_service_pb2.py \
+  cp bazel-serving/tensorflow_serving/apis/*_pb2.py \
+    "${TMPDIR}/tensorflow_serving/apis"
+
+  cp bazel-serving/tensorflow_serving/apis/*_grpc.py \
     "${TMPDIR}/tensorflow_serving/apis"
 
   touch "${TMPDIR}/tensorflow_serving/apis/__init__.py"


### PR DESCRIPTION
Right now pip packages don't include meta model query `pb2.py` so that user can't query model status through grpc

This pr add them 