### PR TITLE
Add weighted model selection

### DIFF
--- a/tensorflow_serving/core/servable_handle.h
+++ b/tensorflow_serving/core/servable_handle.h
@@ -81,6 +81,12 @@ class ServableHandle {
   /// ServableHandle is null by default.
   ServableHandle() = default;
 
+  explicit ServableHandle(std::unique_ptr<UntypedServableHandle> untyped_handle)
+      : untyped_handle_(std::move(untyped_handle)),
+        servable_(untyped_handle_ == nullptr
+                  ? nullptr
+                  : untyped_handle_->servable().get<T>()) {}
+
   const ServableId& id() const { return untyped_handle_->id(); }
 
   // Smart pointer operations.
@@ -98,12 +104,6 @@ class ServableHandle {
 
  private:
   friend class Manager;
-
-  explicit ServableHandle(std::unique_ptr<UntypedServableHandle> untyped_handle)
-      : untyped_handle_(std::move(untyped_handle)),
-        servable_(untyped_handle_ == nullptr
-                      ? nullptr
-                      : untyped_handle_->servable().get<T>()) {}
 
   std::unique_ptr<UntypedServableHandle> untyped_handle_;
   T* servable_ = nullptr;

--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -41,6 +41,8 @@ cc_library(
         "//tensorflow_serving/servables/tensorflow:saved_model_bundle_source_adapter_proto",
         "//tensorflow_serving/servables/tensorflow:session_bundle_config_proto",
         "//tensorflow_serving/servables/tensorflow:session_bundle_source_adapter_proto",
+        "//tensorflow_serving/servables/selector:model_selector_source_adapter_proto",
+        "//tensorflow_serving/servables/selector:model_selector_source_adapter", # For REGISTER_STORAGE_PATH_SOURCE_ADAPTER
     ],
 )
 
@@ -222,6 +224,7 @@ cc_binary(
         "//tensorflow_serving/apis:prediction_service_proto",
         "//tensorflow_serving/config:model_server_config_proto",
         "//tensorflow_serving/core:availability_preserving_policy",
+        "//tensorflow_serving/util:proto_util",
         "@grpc//:grpc++_unsecure",
     ] + TENSORFLOW_DEPS + SUPPORTED_TENSORFLOW_OPS,
 )

--- a/tensorflow_serving/model_servers/model_platform_types.h
+++ b/tensorflow_serving/model_servers/model_platform_types.h
@@ -20,6 +20,7 @@ namespace tensorflow {
 namespace serving {
 
 constexpr char kTensorFlowModelPlatform[] = "tensorflow";
+constexpr char kModelSelectorPlatform[] = "model_selector";
 
 }  // namespace serving
 }  // namespace tensorflow

--- a/tensorflow_serving/model_servers/platform_config_util.cc
+++ b/tensorflow_serving/model_servers/platform_config_util.cc
@@ -19,13 +19,15 @@ limitations under the License.
 #include "tensorflow_serving/model_servers/model_platform_types.h"
 #include "tensorflow_serving/servables/tensorflow/saved_model_bundle_source_adapter.pb.h"
 #include "tensorflow_serving/servables/tensorflow/session_bundle_source_adapter.pb.h"
+#include "tensorflow_serving/servables/selector/model_selector_source_adapter.pb.h"
 
 namespace tensorflow {
 namespace serving {
 
-PlatformConfigMap CreateTensorFlowPlatformConfigMap(
+PlatformConfigMap CreateDefaultPlatformConfigMap(
     const SessionBundleConfig& session_bundle_config, bool use_saved_model) {
   PlatformConfigMap platform_config_map;
+
   ::google::protobuf::Any source_adapter_config;
   if (use_saved_model) {
     SavedModelBundleSourceAdapterConfig
@@ -40,6 +42,12 @@ PlatformConfigMap CreateTensorFlowPlatformConfigMap(
     source_adapter_config.PackFrom(session_bundle_source_adapter_config);
   }
   (*(*platform_config_map.mutable_platform_configs())[kTensorFlowModelPlatform]
+        .mutable_source_adapter_config()) = source_adapter_config;
+
+  ModelSelectorSourceAdapterConfig model_selector_source_adapter_config;
+  model_selector_source_adapter_config.set_filename("selector.conf");
+  source_adapter_config.PackFrom(model_selector_source_adapter_config);
+  (*(*platform_config_map.mutable_platform_configs())[kModelSelectorPlatform]
         .mutable_source_adapter_config()) = source_adapter_config;
   return platform_config_map;
 }

--- a/tensorflow_serving/model_servers/platform_config_util.h
+++ b/tensorflow_serving/model_servers/platform_config_util.h
@@ -26,7 +26,7 @@ namespace serving {
 // kTensorFlowModelPlatform and the value as a SourceAdapter config proto for
 // one of {SessionBundleSourceAdapter, SavedModelBundleSourceAdapter} (based
 // on 'use_saved_model' using 'session_bundle_config'.
-PlatformConfigMap CreateTensorFlowPlatformConfigMap(
+PlatformConfigMap CreateDefaultPlatformConfigMap(
     const SessionBundleConfig& session_bundle_config, bool use_saved_model);
 
 }  // namespace serving

--- a/tensorflow_serving/model_servers/server_core.h
+++ b/tensorflow_serving/model_servers/server_core.h
@@ -206,6 +206,19 @@ class ServerCore : public Manager {
     return Status::OK();
   }
 
+
+  Status GetUntypedServableHandle(const ModelSpec& model_spec,
+                                  std::unique_ptr<UntypedServableHandle>* untyped_handle) {
+    ServableRequest servable_request;
+    tensorflow::Status status =
+            ServableRequestFromModelSpec(model_spec, &servable_request);
+    if (!status.ok()) {
+      VLOG(1) << "Unable to get servable handle due to: " << status;
+      return status;
+    }
+    return GetUntypedServableHandle(servable_request, untyped_handle);
+  }
+
   /// Writes the log for the particular request, response and metadata, if we
   /// decide to sample it and if request-logging was configured for the
   /// particular model.

--- a/tensorflow_serving/servables/selector/BUILD
+++ b/tensorflow_serving/servables/selector/BUILD
@@ -1,0 +1,52 @@
+cc_library(
+    name = "model_selector",
+    srcs = ["model_selector.cc"],
+    hdrs = ["model_selector.h"],
+    deps = [
+        ":model_selector_proto",
+        "//tensorflow_serving/apis:model_proto",
+        "//tensorflow_serving/servables/tensorflow:util",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+cc_library(
+    name = "model_selector_source_adapter",
+    srcs = ["model_selector_source_adapter.cc"],
+    hdrs = ["model_selector_source_adapter.h"],
+    deps = [
+        ":model_selector",
+        ":model_selector_source_adapter_proto",
+        "//tensorflow_serving/core:simple_loader",
+        "//tensorflow_serving/core:source_adapter",
+        "//tensorflow_serving/core:storage_path",
+        "//tensorflow_serving/util:proto_util",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    alwayslink = 1,
+)
+
+load("//tensorflow_serving:serving.bzl", "serving_proto_library")
+
+serving_proto_library(
+    name = "model_selector_proto",
+    srcs = ["model_selector.proto"],
+    deps = [
+        "//tensorflow_serving/apis:model_proto",
+        "@protobuf_archive//:cc_wkt_protos",
+    ],
+    cc_api_version = 2,
+)
+
+serving_proto_library(
+    name = "model_selector_source_adapter_proto",
+    srcs = ["model_selector_source_adapter.proto"],
+    visibility = [
+        "//visibility:public",
+    ],
+    cc_api_version = 2,
+)

--- a/tensorflow_serving/servables/selector/model_selector.cc
+++ b/tensorflow_serving/servables/selector/model_selector.cc
@@ -1,0 +1,35 @@
+#include <random>
+
+#include "tensorflow_serving/servables/selector/model_selector.h"
+#include "tensorflow_serving/servables/tensorflow/util.h"
+
+namespace tensorflow {
+namespace serving {
+
+Status ModelSelector::GetModelSpec(const std::string& signature_def, ModelSpec* model_spec) const {
+  static thread_local std::mt19937 mt;
+  std::uniform_real_distribution<float> rand(0.0, sum_weights);
+  auto r = rand(mt);
+  for (auto& candidate : candidates) {
+    r -= candidate.weight();
+    if (r <= 0) {
+      auto name = candidate.name();
+      auto group_iter = signature_groups.find(signature_def);
+      if (group_iter == signature_groups.end()) {
+        return errors::Internal("Cannot find signatureGroup of ", signature_def);
+      }
+      auto signatures = group_iter->second.signatures();
+      auto signature_iter = signatures.find(name);
+      if (signature_iter == signatures.end()) {
+        return errors::Internal("Cannot find signature_def of ", name);
+      }
+      MakeModelSpec(name, signature_iter->second,
+                    candidate.has_version() ? make_optional(candidate.version().value()) : nullopt, model_spec);
+      return Status::OK();
+    }
+  }
+  return errors::Internal("Something wrong.");
+}
+
+} // namespace serving
+} // namespace tensorflow

--- a/tensorflow_serving/servables/selector/model_selector.h
+++ b/tensorflow_serving/servables/selector/model_selector.h
@@ -1,0 +1,26 @@
+#ifndef TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_H_
+#define TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_H_
+
+#include "tensorflow_serving/servables/selector/model_selector.pb.h"
+#include "tensorflow_serving/apis/model.pb.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+namespace serving {
+
+class ModelSelector {
+public:
+  ModelSelector(float sum_weights, const std::vector<Candidate>& candidates, const google::protobuf::Map<std::string, SignatureGroup>& signature_groups)
+          : sum_weights(sum_weights), candidates(candidates), signature_groups(signature_groups) {}
+  ~ModelSelector();
+  Status GetModelSpec(const std::string& signature_def, ModelSpec* model_sepc) const;
+private:
+  const float sum_weights;
+  const std::vector<Candidate> candidates;
+  const google::protobuf::Map<std::string, SignatureGroup> signature_groups;
+};
+
+} // namespace serving
+} // namespace tensorflow
+
+#endif // TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_H_

--- a/tensorflow_serving/servables/selector/model_selector.proto
+++ b/tensorflow_serving/servables/selector/model_selector.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+
+import "google/protobuf/wrappers.proto";
+import "tensorflow_serving/apis/model.proto";
+
+package tensorflow.serving;
+
+message Candidate {
+    string name = 1;
+    google.protobuf.Int64Value version = 2;
+    float weight = 3;
+}
+
+message SignatureGroup {
+    map<string, string> signatures = 1;
+}
+
+message ModelSelectorConfig {
+    repeated Candidate candidates = 1;
+    map<string, SignatureGroup> signatureGroups = 2;
+}

--- a/tensorflow_serving/servables/selector/model_selector_source_adapter.cc
+++ b/tensorflow_serving/servables/selector/model_selector_source_adapter.cc
@@ -1,0 +1,46 @@
+#include "tensorflow_serving/servables/selector/model_selector_source_adapter.h"
+
+#include "tensorflow_serving/util/proto_util.h"
+
+namespace tensorflow {
+namespace serving {
+
+Status LoadModelSelectorFromFile(const string& path,
+                                 const string& file_name,
+                                 std::unique_ptr<ModelSelector>* selector) {
+  auto config = ReadProtoFromFile<ModelSelectorConfig>(path + "/" + file_name);
+  std::vector<Candidate> candidates;
+  candidates.reserve(config.candidates_size());
+  float sum_weights = 0;
+  for (auto& candidate : config.candidates()) {
+    sum_weights += candidate.weight();
+    candidates.push_back(candidate);
+  }
+  selector->reset(new ModelSelector(sum_weights, candidates, config.signaturegroups()));
+  return Status::OK();
+}
+
+ModelSelectorSourceAdapter::ModelSelectorSourceAdapter(
+        const ModelSelectorSourceAdapterConfig& config)
+        : SimpleLoaderSourceAdapter<StoragePath, ModelSelector>(
+        [config](const StoragePath& path, std::unique_ptr<ModelSelector>* selector) {
+          return LoadModelSelectorFromFile(path, config.filename(), selector);
+        },
+        SimpleLoaderSourceAdapter<StoragePath, ModelSelector>::EstimateNoResources()) {}
+
+ModelSelectorSourceAdapter::~ModelSelectorSourceAdapter() { Detach(); }
+
+class ModelSelectorSourceAdapterCreator {
+public:
+  static Status Create(
+          const ModelSelectorSourceAdapterConfig& config,
+          std::unique_ptr<SourceAdapter<StoragePath, std::unique_ptr<Loader>>>* adapter) {
+    adapter->reset(new ModelSelectorSourceAdapter(config));
+    return Status::OK();
+  }
+};
+
+REGISTER_STORAGE_PATH_SOURCE_ADAPTER(ModelSelectorSourceAdapterCreator, ModelSelectorSourceAdapterConfig);
+
+} // namespace serving
+} // namespace tensorlfow

--- a/tensorflow_serving/servables/selector/model_selector_source_adapter.h
+++ b/tensorflow_serving/servables/selector/model_selector_source_adapter.h
@@ -1,0 +1,25 @@
+#ifndef TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_SOURCE_ADAPTER_H_
+#define TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_SOURCE_ADAPTER_H_
+
+#include "tensorflow_serving/core/storage_path.h"
+#include "tensorflow_serving/core/simple_loader.h"
+#include "tensorflow_serving/servables/selector/model_selector.h"
+#include "tensorflow_serving/servables/selector/model_selector_source_adapter.pb.h"
+
+namespace tensorflow {
+namespace serving {
+
+class ModelSelectorSourceAdapter final
+        : public SimpleLoaderSourceAdapter<StoragePath, ModelSelector> {
+public:
+  explicit ModelSelectorSourceAdapter(const ModelSelectorSourceAdapterConfig& config);
+  ~ModelSelectorSourceAdapter() override;
+
+private:
+  TF_DISALLOW_COPY_AND_ASSIGN(ModelSelectorSourceAdapter);
+};
+
+} // namespace serving
+} // namespace tensorflow
+
+#endif // TENSORFLOW_SERVING_SERVABLES_PROVIDER_MODEL_SELECTOR_SOURCE_ADAPTER_H_

--- a/tensorflow_serving/servables/selector/model_selector_source_adapter.proto
+++ b/tensorflow_serving/servables/selector/model_selector_source_adapter.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package tensorflow.serving;
+
+message ModelSelectorSourceAdapterConfig {
+    string fileName = 1;
+}

--- a/tensorflow_serving/servables/tensorflow/BUILD
+++ b/tensorflow_serving/servables/tensorflow/BUILD
@@ -422,6 +422,7 @@ cc_library(
         "//tensorflow_serving/apis:predict_proto",
         "//tensorflow_serving/core:servable_handle",
         "//tensorflow_serving/model_servers:server_core",
+        "//tensorflow_serving/servables/selector:model_selector",
         "//tensorflow_serving/servables/tensorflow:util",
         "@org_tensorflow//tensorflow/cc/saved_model:loader",
         "@org_tensorflow//tensorflow/cc/saved_model:signature_constants",

--- a/tensorflow_serving/util/BUILD
+++ b/tensorflow_serving/util/BUILD
@@ -317,6 +317,16 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "proto_util",
+    srcs = ["proto_util.cc"],
+    hdrs = ["proto_util.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_tensorflow//tensorflow/core:lib",
+    ]
+)
+
 load("//tensorflow_serving:serving.bzl", "serving_proto_library")
 load("//tensorflow_serving:serving.bzl", "serving_proto_library_py")
 

--- a/tensorflow_serving/util/any_ptr.h
+++ b/tensorflow_serving/util/any_ptr.h
@@ -89,6 +89,11 @@ class AnyPtr {
     return reinterpret_cast<T*>(ptr_);
   }
 
+  template <typename T>
+  bool isType() const {
+    return type_id_ == FastTypeId<T>();
+  }
+
  private:
   template <typename Type>
   static size_t FastTypeId() {

--- a/tensorflow_serving/util/proto_util.cc
+++ b/tensorflow_serving/util/proto_util.cc
@@ -1,0 +1,33 @@
+#include "tensorflow_serving/util/proto_util.h"
+
+#include "tensorflow/core/platform/env.h"
+
+namespace tensorflow {
+namespace serving {
+
+tensorflow::Status ParseProtoTextFile(const string& file,
+                                      google::protobuf::Message* message) {
+  std::unique_ptr<tensorflow::ReadOnlyMemoryRegion> file_data;
+  TF_RETURN_IF_ERROR(
+          tensorflow::Env::Default()->NewReadOnlyMemoryRegionFromFile(file,
+                                                                      &file_data));
+  string file_data_str(static_cast<const char*>(file_data->data()),
+                       file_data->length());
+  if (tensorflow::protobuf::TextFormat::ParseFromString(file_data_str,
+                                                        message)) {
+    return tensorflow::Status::OK();
+  } else {
+    return tensorflow::errors::InvalidArgument("Invalid protobuf file: '", file,
+                                               "'");
+  }
+}
+
+/*template <typename ProtoType>
+ProtoType ReadProtoFromFile(const string& file) {
+  ProtoType proto;
+  TF_CHECK_OK(ParseProtoTextFile(file, &proto));
+  return proto;
+}*/
+
+} // namespace serving
+} // namespace tensorflow

--- a/tensorflow_serving/util/proto_util.h
+++ b/tensorflow_serving/util/proto_util.h
@@ -1,0 +1,23 @@
+#ifndef TENSORFLOW_SERVING_UTIL_PROTO_UTIL_H_
+#define TENSORFLOW_SERVING_UTIL_PROTO_UTIL_H_
+
+#include <google/protobuf/message.h>
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+namespace serving {
+
+tensorflow::Status ParseProtoTextFile(const string& file,
+                                      google::protobuf::Message* message);
+
+template <typename ProtoType>
+ProtoType ReadProtoFromFile(const string& file) {
+  ProtoType proto;
+  TF_CHECK_OK(ParseProtoTextFile(file, &proto));
+  return proto;
+}
+
+}
+}
+
+#endif // TENSORFLOW_SERVING_UTIL_PROTO_UTIL_H_


### PR DESCRIPTION
I added weighted model selection as a new servable.
I think this is helpful for A/B testing. 

## Example usage

1. Specify model weights as follows in `/tmp/selector/1/selector.conf`.
```
candidates: {
  name: "mnist1"
  weight: 0.1
}
candidates: {
  name: "mnist2"
  weight: 0.9
}
signatureGroups: {
  key: "predict_images"
  value: {
    signatures: {
      key: "mnist1"
      value: "predict_images"
    }
    signatures: {
      key: "mnist2"
      value: "predict_images"
    }
  }
}
```

2. Specify model config as follows in `models.conf`.
```
model_config_list: {
  config: {
    name: "mnist1",
    base_path: "/tmp/mnist_model1/",
    model_platform: "tensorflow",
  },
  config: {
    name: "mnist2",
    base_path: "/tmp/mnist_model2/",
    model_platform: "tensorflow",
  },
  config: {
    name: "weighted_mnist",
    base_path: "/tmp/selector",
    model_platform: "model_selector",
  },
}
```

3. Send a request using following model_spec.
```
name: weighted_mnist
signature_def: predict_images
```

## Note
Currently, I added this feature to only Predict I/F. If this is worth to merge, I will add this to another I/Fs and add tests.
 