### PR TITLE
Add instructions for building SSL-enabled TensorFlow Serving.

### DIFF
--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -209,3 +209,18 @@ CI_TENSORFLOW_SUBMODULE_PATH=tensorflow tensorflow/tensorflow/tools/ci_build/ci_
 Note: The `serving` directory is mapped into the container. You can develop
 outside the docker container (in your favourite editor) and when you run this
 build it will build with your changes.
+
+### Build with secure gRPC (SSL support)
+
+TensorFlow Serving builds are linked to a version of gRPC with SSL support
+disabled. This means that any use of [the secure sever credentials](https://github.com/grpc/grpc/blob/master/include/grpcpp/security/server_credentials.h)
+will silently fail - the server will listen on the port indicated, but will only
+accept unencrypted connections.
+
+To enable SSL support, remove the `_unsecure` prefix from the `grpc_lib` bind in
+`workspace.bzl` and in the model server dependencies before building:
+
+```shell
+sed -i '' 's/c\+\+_unsecure/c++/g' tensorflow_serving/workspace.bzl \
+    tensorflow_serving/model_servers/BUILD
+```

--- a/tensorflow_serving/workspace.bzl
+++ b/tensorflow_serving/workspace.bzl
@@ -36,3 +36,12 @@ def tf_serving_workspace():
       name = "cares",
       actual = "@grpc//third_party/nanopb:nanopb",
   )
+
+  # gRPC requires a bind() for linking; see
+  # https://github.com/grpc/grpc/issues/13590 for a discussion.  This can be
+  # re-bound to target `grcp++` if you wish to build TensorFlow Serving with SSL
+  # support enabled.
+  native.bind(
+      name = "grpc_lib",
+      actual = "@grpc//:grpc++_unsecure",
+  )


### PR DESCRIPTION
Note that the `bind()` call is a no-op. If I understand how this is working now, it's overriding a value inherited [from TensorFlow](https://github.com/tensorflow/tensorflow/blob/0abc4c9ecae912676f6070ca4b76b35c80351c26/tensorflow/workspace.bzl#L772-L777).

Partial fix for #193 .