### PR TITLE
Added model config retrieve gRPC API

### DIFF
--- a/tensorflow_serving/apis/model_management.proto
+++ b/tensorflow_serving/apis/model_management.proto
@@ -13,3 +13,10 @@ message ReloadConfigRequest {
 message ReloadConfigResponse {
     StatusProto status = 1;
 }
+
+message GetConfigRequest {
+}
+
+message GetConfigResponse {
+    ModelServerConfig config = 1;
+}

--- a/tensorflow_serving/apis/model_service.proto
+++ b/tensorflow_serving/apis/model_service.proto
@@ -19,4 +19,7 @@ service ModelService {
   // Reloads the set of served models. The new config supersedes the old one, so if a
   // model is omitted from the new config it will be unloaded and no longer served.
   rpc HandleReloadConfigRequest(ReloadConfigRequest) returns (ReloadConfigResponse);
+
+  // Provides actual server config to use as source for further modifications via reload
+  rpc HandleGetConfigRequest(GetConfigRequest) returns (GetConfigResponse);
 }

--- a/tensorflow_serving/model_servers/model_service_impl.cc
+++ b/tensorflow_serving/model_servers/model_service_impl.cc
@@ -66,5 +66,12 @@ namespace tensorflow {
       return ToGRPCStatus(status);
     }
 
+    ::grpc::Status ModelServiceImpl::HandleGetConfigRequest(::grpc::ServerContext *context,
+                                                            const GetConfigRequest *request,
+                                                            GetConfigResponse *response) {
+      ModelServerConfig config = core_->GetConfig();
+      *response->mutable_config() = config;
+      return ToGRPCStatus(Status::OK());
+    }
   }  // namespace serving
 }  // namespace tensorflow

--- a/tensorflow_serving/model_servers/model_service_impl.h
+++ b/tensorflow_serving/model_servers/model_service_impl.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow_serving/apis/model_service.pb.h"
 #include "tensorflow_serving/model_servers/server_core.h"
 #include "tensorflow_serving/apis/model_management.pb.h"
+#include "tensorflow_serving/apis/model.pb.h"
 
 namespace tensorflow {
   namespace serving {
@@ -37,6 +38,10 @@ namespace tensorflow {
       ::grpc::Status HandleReloadConfigRequest(::grpc::ServerContext *context,
                                                const ReloadConfigRequest *request,
                                                ReloadConfigResponse *response);
+
+      ::grpc::Status HandleGetConfigRequest(::grpc::ServerContext *context,
+                                            const GetConfigRequest *request,
+                                            GetConfigResponse *response);
 
     private:
       ServerCore *core_;

--- a/tensorflow_serving/model_servers/server_core.cc
+++ b/tensorflow_serving/model_servers/server_core.cc
@@ -471,6 +471,14 @@ Status ServerCore::ReloadConfig(const ModelServerConfig& new_config) {
   return Status::OK();
 }
 
+ModelServerConfig ServerCore::GetConfig() {
+  mutex_lock l(config_mu_);
+  ModelServerConfig config;
+  config = config_.operator=(config_);
+  VLOG(1) << "Sending server config: " << config.SerializeAsString();
+  return config;
+}
+
 Status ServerCore::CreateAdapter(
     const string& model_platform,
     std::unique_ptr<StoragePathSourceAdapter>* adapter) const {

--- a/tensorflow_serving/model_servers/server_core.h
+++ b/tensorflow_serving/model_servers/server_core.h
@@ -176,6 +176,10 @@ class ServerCore : public Manager {
   virtual Status ReloadConfig(const ModelServerConfig& config)
       LOCKS_EXCLUDED(config_mu_);
 
+  /// Returns actual ModelConfigList with all the models and sources
+  virtual ModelServerConfig GetConfig()
+      LOCKS_EXCLUDED(config_mu_);
+
   /// Returns ServableStateMonitor that can be used to query servable states.
   virtual ServableStateMonitor* servable_state_monitor() const {
     return servable_state_monitor_.get();


### PR DESCRIPTION
In addition to config reload we now need to be able retrieve actual config from server - to modify it and send back when we don't wan't to unload some existing deployed model.