### PR TITLE
fix channel args parsing

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -304,8 +304,8 @@ void RunServer(int port, std::unique_ptr<ServerCore> core, bool use_saved_model,
     // gRPC accept arguments of two types, int and string. We will attempt to
     // parse each arg as int and pass it on as such if successful. Otherwise we
     // will pass it as a string. gRPC will log arguments that were not accepted.
-    int value;
-    if (tensorflow::strings::safe_strto32(channel_argument.key, &value)) {
+    tensorflow::int32 value;
+    if (tensorflow::strings::safe_strto32(channel_argument.value, &value)) {
       builder.AddChannelArgument(channel_argument.key, value);
     } else {
       builder.AddChannelArgument(channel_argument.key, channel_argument.value);


### PR DESCRIPTION
A bug sneaked in here.

There is an integration test for this, but I haven't been able to figure out if/how I can run them.

Meanwhile I have some evidence it works now.

-----

```
$ ./bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server --model_base_path=/home/ubuntu/model/ --grpc_channel_arguments=grpc.max_connection_age
_ms=10
```
```
$ time telnet localhost 8500
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
@@ max_ageConnection closed by foreign host.

real	0m0.013s
user	0m0.000s
sys	0m0.000s
```

-----

```
$ ./bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server --model_base_path=/home/ubuntu/model/ --grpc_channel_arguments=grpc.max_connection_age
_ms=1000
```
```
$ time telnet localhost 8500
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
@@ max_ageConnection closed by foreign host.

real	0m0.981s
user	0m0.000s
sys	0m0.000s
```