### PR TITLE
Support runtime model_config_file reload

### DIFF
--- a/tensorflow_serving/model_servers/config_reloader.cc
+++ b/tensorflow_serving/model_servers/config_reloader.cc
@@ -1,0 +1,77 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow_serving/model_servers/config_reloader.h"
+
+#include <string>
+#include <utility>
+#include <thread>
+#include <sys/stat.h>
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow_serving/config/model_server_config.pb.h"
+#include "tensorflow_serving/core/source.h"
+#include "tensorflow_serving/core/storage_path.h"
+#include "tensorflow_serving/sources/storage_path/file_system_storage_path_source.h"
+
+namespace tensorflow {
+namespace serving {
+
+bool ConfigReloader::Start() {
+  exit_ = false;
+  stop_loading_ = false;
+  loading_thread_.reset(new std::thread(std::bind(&ConfigReloader::Run, this)));
+  return true;
+}
+
+bool ConfigReloader::Stop() {
+  exit_ = true;
+  stop_loading_ = true;
+  return true;
+}
+
+void ConfigReloader::Run() {
+  while (!exit_) {
+    Reload();
+    // sleep
+    std::this_thread::sleep_for(std::chrono::seconds(kInterval));
+  }
+}
+
+void ConfigReloader::Reload() {
+  if (!Env::Default()->FileExists(file_path_).ok()) {
+    LOG(INFO) << "Config file not exist: " << file_path_;
+    return;
+  }
+  struct stat file_stat;
+  if (-1 == stat(file_path_.c_str(), &file_stat)) {
+    LOG(INFO) << "Failed to stat: " << file_path_;
+    return;
+  }
+  time_t modifiled_time = file_stat.st_mtime;
+  if (modifiled_time <= last_modified_time_) {
+    return;
+  }
+  last_modified_time_ = modifiled_time;
+  if (reload_func_) {
+    reload_func_();
+  }
+}
+
+}  // namespace serving
+}  // namespace tensorflow

--- a/tensorflow_serving/model_servers/config_reloader.h
+++ b/tensorflow_serving/model_servers/config_reloader.h
@@ -1,0 +1,70 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_SERVING_MODEL_SERVERS_CONFIG_LOADER_H_
+#define TENSORFLOW_SERVING_MODEL_SERVERS_CONFIG_LOADER_H_
+
+#include <string>
+#include <utility>
+#include <thread>
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow_serving/config/model_server_config.pb.h"
+#include "tensorflow_serving/core/source.h"
+#include "tensorflow_serving/core/storage_path.h"
+#include "tensorflow_serving/sources/storage_path/file_system_storage_path_source.h"
+
+namespace tensorflow {
+namespace serving {
+
+class ConfigReloader {
+ public:
+  ConfigReloader(const std::string& file_path, bool stop_loading = false)
+      : file_path_(file_path), stop_loading_(stop_loading) {}
+  virtual ~ConfigReloader() {
+    if (loading_thread_) {
+      loading_thread_->join();
+    }
+  }
+  ConfigReloader(const ConfigReloader&) = delete;
+  ConfigReloader& operator=(const ConfigReloader&) = delete;
+
+  virtual bool Start();
+  virtual bool Stop();
+  const string& GetFilePath() { return file_path_; }
+  void SetReloadFunc(std::function<void()> reload_func) {
+    reload_func_ = reload_func;
+  }
+
+ protected:
+  const int32_t kInterval{ 1 };
+  volatile bool exit_;
+  volatile bool stop_loading_;
+  std::unique_ptr<std::thread> loading_thread_;
+  std::string file_path_;
+  time_t last_modified_time_{ 0 };
+  std::function<void()> reload_func_;
+
+  virtual void Run();
+  void Reload();
+};
+
+}  // namespace serving
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_SERVING_MODEL_SERVERS_CONFIG_LOADER_H_


### PR DESCRIPTION
Support runtime model_config_file reload.
when using --model_config_file, tf-serving starts a new thread that polls filesystem and triggers loading or unloading action by calling ServerCore::ReloadConfig(). It has been verified on our production prediction engin for easily releasing new models, makes it convenient for both multiple-model and multiple-version a/b test.