### PR TITLE
Prepare for 1.8.0 TF serving release.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,19 +11,19 @@ load("//tensorflow_serving:repo.bzl", "tensorflow_http_archive")
 
 tensorflow_http_archive(
     name = "org_tensorflow",
-    sha256 = "876f800cf9605375c4a05daf44bc280bcb85ef5b302a9c01592a828c61647574",
-    git_commit = "694892d4c0fba6bd4322e943f8b1483b36f1ae99",
+    sha256 = "47646952590fd213b747247e6870d89bb4a368a95ae3561513d6c76e44f92a75",
+    git_commit = "93bc2e2072e0daccbcff7a90d397b704a9e8f778",
 )
 
 # TensorFlow depends on "io_bazel_rules_closure" so we need this here.
 # Needs to be kept in sync with the same target in TensorFlow's WORKSPACE file.
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "a38539c5b5c358548e75b44141b4ab637bba7c4dc02b46b1f62a96d6433f56ae",
-    strip_prefix = "rules_closure-dbb96841cc0a5fb2664c37822803b06dab20c7d1",
+    sha256 = "6691c58a2cd30a86776dd9bb34898b041e37136f2dc7e24cadaeaf599c95c657",
+    strip_prefix = "rules_closure-08039ba8ca59f64248bb3b6ae016460fe9c9914f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/dbb96841cc0a5fb2664c37822803b06dab20c7d1.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/dbb96841cc0a5fb2664c37822803b06dab20c7d1.tar.gz",  # 2018-04-13
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",  # 2018-01-16
     ],
 )
 

--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -348,7 +348,7 @@ pkg_deb(
     homepage = "https://github.com/tensorflow/serving",
     maintainer = "TensorFlow Serving team",
     package = "tensorflow-model-server",
-    version = "undefined",  # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
+    version = "1.8.0",  # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
 )
 
 # Build with '-c opt'
@@ -359,5 +359,5 @@ pkg_deb(
     homepage = "https://github.com/tensorflow/serving",
     maintainer = "TensorFlow Serving team",
     package = "tensorflow-model-server-universal",
-    version = "undefined",  # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
+    version = "1.8.0",  # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
 )

--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -17,10 +17,10 @@ from setuptools import find_packages
 from setuptools import setup
 
 # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
-_VERSION = 'undefined'
+_VERSION = '1.8.0'
 
 REQUIRED_PACKAGES = [
-    'tensorflow>=1.2.0,<2',
+    'tensorflow>=1.8.0,<2',
     'grpcio>=1.0<2',
 ]
 


### PR DESCRIPTION
- Pin to TensorFlow 1.8.0 release.
- Pin package version numbers.