### PR TITLE
Add util for get model status

### DIFF
--- a/tensorflow_serving/tools/pip_package/BUILD
+++ b/tensorflow_serving/tools/pip_package/BUILD
@@ -22,6 +22,10 @@ sh_binary(
         "//tensorflow_serving/apis:predict_proto_py_pb2",
         "//tensorflow_serving/apis:regression_proto_py_pb2",
         "//tensorflow_serving/apis:session_service_proto_py_pb2",
+        "//tensorflow_serving/config:log_collector_config_proto_py_pb2",
+        "//tensorflow_serving/config:logging_config_proto_py_pb2",
+        "//tensorflow_serving/config:model_server_config_proto_py_pb2",
+        "//tensorflow_serving/sources/storage_path:file_system_storage_path_source_proto_py_pb2",
         "//tensorflow_serving/util:status_proto_py_pb2",
     ],
 )

--- a/tensorflow_serving/tools/pip_package/BUILD
+++ b/tensorflow_serving/tools/pip_package/BUILD
@@ -22,5 +22,6 @@ sh_binary(
         "//tensorflow_serving/apis:predict_proto_py_pb2",
         "//tensorflow_serving/apis:regression_proto_py_pb2",
         "//tensorflow_serving/apis:session_service_proto_py_pb2",
+        "//tensorflow_serving/util:status_proto_py_pb2",
     ],
 )

--- a/tensorflow_serving/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_serving/tools/pip_package/build_pip_package.sh
@@ -34,6 +34,8 @@ function main() {
 
   echo $(date) : "=== Using tmpdir: ${TMPDIR}"
   mkdir -p ${TMPDIR}/tensorflow_serving/apis
+  mkdir -p ${TMPDIR}/tensorflow_serving/util
+  mkdir -p ${TMPDIR}/tensorflow/core/lib/core
 
   echo "Adding python files"
   cp bazel-genfiles/tensorflow_serving/apis/*_pb2.py \
@@ -44,9 +46,20 @@ function main() {
 
   cp bazel-serving/tensorflow_serving/apis/*_grpc.py \
     "${TMPDIR}/tensorflow_serving/apis"
+  
+  cp bazel-genfiles/tensorflow_serving/util/*_pb2.py \
+    "${TMPDIR}/tensorflow_serving/util"
+
+  cp bazel-genfiles/external/org_tensorflow/tensorflow/core/lib/core/*.py \
+    "${TMPDIR}/tensorflow/core/lib/core"
 
   touch "${TMPDIR}/tensorflow_serving/apis/__init__.py"
+  touch "${TMPDIR}/tensorflow_serving/util/__init__.py"
   touch "${TMPDIR}/tensorflow_serving/__init__.py"
+  touch "${TMPDIR}/tensorflow/__init__.py"
+  touch "${TMPDIR}/tensorflow/core/__init__.py"
+  touch "${TMPDIR}/tensorflow/core/lib/__init__.py"
+  touch "${TMPDIR}/tensorflow/core/lib/core/__init__.py"
 
   echo "Adding package setup files"
   cp ${PIP_SRC_DIR}/setup.py "${TMPDIR}"

--- a/tensorflow_serving/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_serving/tools/pip_package/build_pip_package.sh
@@ -34,6 +34,8 @@ function main() {
 
   echo $(date) : "=== Using tmpdir: ${TMPDIR}"
   mkdir -p ${TMPDIR}/tensorflow_serving/apis
+  mkdir -p ${TMPDIR}/tensorflow_serving/config
+  mkdir -p ${TMPDIR}/tensorflow_serving/sources/storage_path
   mkdir -p ${TMPDIR}/tensorflow_serving/util
   mkdir -p ${TMPDIR}/tensorflow/core/lib/core
 
@@ -46,7 +48,13 @@ function main() {
 
   cp bazel-serving/tensorflow_serving/apis/*_grpc.py \
     "${TMPDIR}/tensorflow_serving/apis"
+
+  cp bazel-genfiles/tensorflow_serving/config/*_pb2.py \
+    "${TMPDIR}/tensorflow_serving/config"
   
+  cp bazel-genfiles/tensorflow_serving/sources/storage_path/*_pb2.py \
+    "${TMPDIR}/tensorflow_serving/sources/storage_path"
+
   cp bazel-genfiles/tensorflow_serving/util/*_pb2.py \
     "${TMPDIR}/tensorflow_serving/util"
 
@@ -54,6 +62,9 @@ function main() {
     "${TMPDIR}/tensorflow/core/lib/core"
 
   touch "${TMPDIR}/tensorflow_serving/apis/__init__.py"
+  touch "${TMPDIR}/tensorflow_serving/config/__init__.py"
+  touch "${TMPDIR}/tensorflow_serving/sources/__init__.py"
+  touch "${TMPDIR}/tensorflow_serving/sources/storage_path/__init__.py"
   touch "${TMPDIR}/tensorflow_serving/util/__init__.py"
   touch "${TMPDIR}/tensorflow_serving/__init__.py"
   touch "${TMPDIR}/tensorflow/__init__.py"

--- a/tensorflow_serving/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_serving/tools/pip_package/build_pip_package.sh
@@ -51,7 +51,7 @@ function main() {
 
   cp bazel-genfiles/tensorflow_serving/config/*_pb2.py \
     "${TMPDIR}/tensorflow_serving/config"
-  
+
   cp bazel-genfiles/tensorflow_serving/sources/storage_path/*_pb2.py \
     "${TMPDIR}/tensorflow_serving/sources/storage_path"
 

--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -34,6 +34,7 @@ _VERSION = 'undefined'
 REQUIRED_PACKAGES = [
     'tensorflow>=1.2.0,<2',
     'grpcio>=1.0<2',
+    'protobuf==3.6.0',
 ]
 
 setup(


### PR DESCRIPTION
In tensorflow-serving-api, [get_model_status](https://github.com/tensorflow/serving/blob/1.9.0/tensorflow_serving/apis/BUILD#L236-L244) requires a generated code from status.proto in util.

```
>>> from tensorflow_serving.apis import get_model_status_pb2
...
ImportError: No module named util
```