### PR TITLE
Adding support for secure channel to modelserver

### DIFF
--- a/tensorflow_serving/config/BUILD
+++ b/tensorflow_serving/config/BUILD
@@ -87,3 +87,11 @@ serving_proto_library_py(
         ":log_collector_config_proto_py_pb2",
     ],
 )
+
+serving_proto_library(
+    name = "ssl_config_proto",
+    srcs = ["ssl_config.proto"],
+    cc_api_version = 2,
+    deps = [
+    ],
+)

--- a/tensorflow_serving/config/ssl_config.proto
+++ b/tensorflow_serving/config/ssl_config.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package tensorflow.serving;
+option cc_enable_arenas = true;
+
+// Configuration for a secure gRPC channel
+message SSLConfig {
+  // private server key for SSL
+  string server_key = 1;
+  // public server certificate
+  string server_cert = 2;
+  //  custom certificate authority
+  string custom_ca = 3;
+  // valid client certificate required ?
+  bool client_verify = 4;
+};

--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -197,7 +197,7 @@ cc_library(
         "//tensorflow_serving/apis:model_management_proto",
         "//tensorflow_serving/apis:model_service_proto",
         "//tensorflow_serving/util:status_util",
-        "@grpc//:grpc++_unsecure",
+        "@grpc//:grpc++",
     ],
 )
 
@@ -209,7 +209,7 @@ cc_library(
         "//visibility:public",
     ],
     deps = [
-        "@grpc//:grpc++_unsecure",
+        "@grpc//:grpc++",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -300,7 +300,7 @@ cc_library(
         "//tensorflow_serving/config:model_server_config_proto",
         "//tensorflow_serving/core:availability_preserving_policy",
         "//tensorflow_serving/servables/tensorflow:multi_inference_helper",
-        "@grpc//:grpc++_unsecure",
+        "@grpc//:grpc++",
         "//tensorflow_serving/servables/tensorflow:session_bundle_config_proto",
     ] + TENSORFLOW_DEPS + SUPPORTED_TENSORFLOW_OPS,
 )

--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -298,6 +298,7 @@ cc_library(
         "@org_tensorflow//tensorflow/core:protos_all_cc",
         "//tensorflow_serving/apis:prediction_service_proto",
         "//tensorflow_serving/config:model_server_config_proto",
+        "//tensorflow_serving/config:ssl_config_proto",
         "//tensorflow_serving/core:availability_preserving_policy",
         "//tensorflow_serving/servables/tensorflow:multi_inference_helper",
         "@grpc//:grpc++",

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -367,29 +367,29 @@ std::shared_ptr<grpc::ServerCredentials> BuildServerCredentialsFromSSLConfigFile
 {
   if (ssl_config_file.empty()) {
     return InsecureServerCredentials();
-  } else {
-    SSLConfig ssl_config = ParseSSLConfig(ssl_config_file);
-
-    grpc::SslServerCredentialsOptions sslOps(ssl_config.client_verify() ?
-        GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
-        GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
-
-    sslOps.force_client_auth = ssl_config.client_verify();
-
-    if (ssl_config.custom_ca().size() > 0) {
-      sslOps.pem_root_certs = ssl_config.custom_ca();
-    }
-
-    grpc::SslServerCredentialsOptions::PemKeyCertPair keycert =
-    {
-        ssl_config.server_key(),
-        ssl_config.server_cert()
-    };
-
-    sslOps.pem_key_cert_pairs.push_back(keycert);
-
-    return grpc::SslServerCredentials(sslOps);
   }
+
+  SSLConfig ssl_config = ParseSSLConfig(ssl_config_file);
+
+  grpc::SslServerCredentialsOptions ssl_ops(ssl_config.client_verify() ?
+    GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
+    GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
+
+  ssl_ops.force_client_auth = ssl_config.client_verify();
+
+  if (ssl_config.custom_ca().size() > 0) {
+    ssl_ops.pem_root_certs = ssl_config.custom_ca();
+  }
+
+  grpc::SslServerCredentialsOptions::PemKeyCertPair keycert =
+  {
+    ssl_config.server_key(),
+    ssl_config.server_cert()
+  };
+
+  ssl_ops.pem_key_cert_pairs.push_back(keycert);
+
+  return grpc::SslServerCredentials(ssl_ops);
 }
 
 }  // namespace

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -44,8 +44,6 @@ limitations under the License.
 // To override the default batching parameters: --batching_parameters_file
 
 #include <unistd.h>
-#include <sstream>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
This is code to add support for secure channel to the modelserver, as requested in https://github.com/tensorflow/serving/issues/193.  You should find me under the SAP corporate CLA agreement contributor list.