### PR TITLE
Fixed parsing of grpc_channel_arguments flag

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -306,7 +306,7 @@ void RunServer(int port, std::unique_ptr<ServerCore> core, bool use_saved_model,
     // parse each arg as int and pass it on as such if successful. Otherwise we
     // will pass it as a string. gRPC will log arguments that were not accepted.
     int value;
-    if (tensorflow::strings::safe_strto32(channel_argument.key, &value)) {
+    if (tensorflow::strings::safe_strto32(channel_argument.value, &value)) {
       builder.AddChannelArgument(channel_argument.key, value);
     } else {
       builder.AddChannelArgument(channel_argument.key, channel_argument.value);


### PR DESCRIPTION
During the parsing as int, the grpc channel key was taken instead of the value.
Issue: https://github.com/tensorflow/serving/issues/1019