### PR TITLE
Fix erroneous formatting of numbers that are larger than 6 digits.

### DIFF
--- a/tensorflow_serving/util/json_tensor_test.cc
+++ b/tensorflow_serving/util/json_tensor_test.cc
@@ -546,6 +546,32 @@ TEST(JsontensorTest, FromJsonSingleBytesTensor) {
     ]})"));
 }
 
+// Tests StrCat() six-digit precision float output is correctly
+// represented in the final (output) JSON string.
+TEST(JsontensorTest, FromJsonSingleFloatTensorSixDigitPrecision) {
+  TensorMap tensormap;
+  ASSERT_TRUE(TextFormat::ParseFromString(R"(
+    dtype: DT_FLOAT
+    tensor_shape {
+      dim { size: 2 }
+      dim { size: 2 }
+    }
+    float_val: 9000000
+    float_val: 999999
+    float_val: .0003
+    float_val: .00003
+    )",
+                                          &tensormap["float_tensor"]));
+
+  string json;
+  TF_EXPECT_OK(MakeJsonFromTensors(tensormap, &json));
+  TF_EXPECT_OK(CompareJsonAllValuesAsStrings(json, R"({
+    "predictions": [
+      [9e+06, 999999.0],
+      [0.0003, 3e-05]
+    ]})"));
+}
+
 TEST(JsontensorTest, FromJsonSingleFloatTensorNonFinite) {
   TensorMap tensormap;
   ASSERT_TRUE(TextFormat::ParseFromString(R"(


### PR DESCRIPTION
Such numbers are converted to scientific notation (by StrCat()).
The code suffixed such numbers with '.0' yielding invalid numbers.

As an example before this fix, 9000000 would get string converted
(incorrectly) to 9e+06.0 instead of 9e+06 -- the latter is correct.
Similarly .00003 gets converted incorrectly to 3e-5.0 instead of
3e-5

Fixes https://github.com/tensorflow/serving/issues/989

PiperOrigin-RevId: 204536301
(cherry picked from commit 6ff5d9f80ef4ae7b69af2e114fed969c163d6c47)