### PR TITLE
openjdk-8-jdk\ is missing a space in Dockerfile.devel and Dockerfile.…

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
         libtool \
         libzmq3-dev \
         mlocate \
-        openjdk-8-jdk\
+        openjdk-8-jdk \
         openjdk-8-jre-headless \
         pkg-config \
         python-dev \

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libnccl-dev=${NCCL_VERSION}-1+cuda9.0 \
         libzmq3-dev \
         mlocate \
-        openjdk-8-jdk\
+        openjdk-8-jdk \
         openjdk-8-jre-headless \
         pkg-config \
         python-dev \


### PR DESCRIPTION
When I built the image through Dockerfile, I found that `openjdk-8-jdk\` lacked a space.