### PR TITLE
add an example for hot reload using gRPC

### DIFF
--- a/tensorflow_serving/example/hot_reload_grpc_example.py
+++ b/tensorflow_serving/example/hot_reload_grpc_example.py
@@ -1,0 +1,38 @@
+#coding=utf-8
+from tensorflow_serving.apis import model_service_pb2
+from tensorflow_serving.apis import model_service_pb2_grpc
+from tensorflow_serving.apis import model_management_pb2
+from tensorflow_serving.config import model_server_config_pb2
+from tensorflow_serving.util import status_pb2
+
+import grpc
+
+def run():
+  channel = grpc.insecure_channel('yourip:yourport')
+  stub = model_service_pb2_grpc.ModelServiceStub(channel)
+  request = model_management_pb2.ReloadConfigRequest()  ##message ReloadConfigRequest
+  model_server_config = model_server_config_pb2.ModelServerConfig()
+
+  config_list = model_server_config_pb2.ModelConfigList()##message ModelConfigList
+  
+  one_config = config_list.config.add() #####try to add one model config
+  one_config.name= "test1"
+  one_config.base_path = "/home/model/model1"
+  one_config.model_platform="tensorflow"
+
+  model_server_config.model_config_list.CopyFrom(config_list) c
+
+  request.config.CopyFrom(model_server_config)
+
+  print(request.IsInitialized())
+  print(request.ListFields())
+
+  responese = stub.HandleReloadConfigRequest(request,10)
+  if responese.status.error_code == 0:
+      print("Reload sucessfully")
+  else:
+      print("Reload failed!")
+      print(responese.status.error_code)
+      print(responese.status.error_message)
+
+run()


### PR DESCRIPTION
Many issues discuss how to update the models during runtime such as #380 #422.
And I found that a useful PR #774 is merged into master. However, many people are not familiar with protobuf (especially ModelConfig.proto, ModelServerConfig.proto, etc) and grpc such as #964 #1057  , and don't know how to make a gRPC hot-reload request. This is an example written in python, showing how to make a gRPC hot-reload request to reload the models.
