### PR TITLE
Meet Alpine Linux requirements for mktemp

### DIFF
--- a/third_party/libevent.BUILD
+++ b/third_party/libevent.BUILD
@@ -54,7 +54,7 @@ genrule(
     outs = include_files + lib_files,
     cmd = "\n".join([
         "export INSTALL_DIR=$$(pwd)/$(@D)/libevent",
-        "export TMP_DIR=$$(mktemp -d -t libevent.XXXXX)",
+        "export TMP_DIR=$$(mktemp -d -t libevent.XXXXXX)",
         "mkdir -p $$TMP_DIR",
         "cp -R $$(pwd)/external/com_github_libevent_libevent/* $$TMP_DIR",
         "cd $$TMP_DIR",


### PR DESCRIPTION
mktemp TEMPLATE must end with XXXXXX in Alpine Linux

% docker run --rm -it alpine:3.6 /bin/sh
/ # mktemp -d -t libevent.XXXXX
mktemp: Invalid argument
/ # mktemp -d -t libevent.XXXXXX
/tmp/libevent.jKecLG
/ # mktemp --help
BusyBox v1.26.2 (2017-11-23 08:40:54 GMT) multi-call binary.

Usage: mktemp [-dt] [-p DIR] [TEMPLATE]

Create a temporary file with name based on TEMPLATE and print its name.
TEMPLATE must end with XXXXXX (e.g. [/dir/]nameXXXXXX).
Without TEMPLATE, -t tmp.XXXXXX is assumed.

	-d	Make directory, not file
	-q	Fail silently on errors
	-t	Prepend base directory name to TEMPLATE
	-p DIR	Use DIR as a base directory (implies -t)
	-u	Do not create anything; print a name

Base directory is: -p DIR, else $TMPDIR, else /tmp