### PR TITLE
update guide doc for custom source

### DIFF
--- a/tensorflow_serving/g3doc/custom_source.md
+++ b/tensorflow_serving/g3doc/custom_source.md
@@ -56,7 +56,8 @@ loaded.
 simple way: it periodically inspects the file system (doing an `ls`,
 essentially), and if it finds one or more paths that look like servable
 versions it determines which one is the latest version and invokes the callback
-with a list of size one containing just that version. So, at any given time
+with a list of size one containing just that version
+(under the default configuration). So, at any given time
 `FileSystemStoragePathSource` requests at most one servable to be loaded, and
 its implementation takes advantage of the idempotence of the callback to keep
 itself stateless (there is no harm in invoking the callback repeatedly with the


### PR DESCRIPTION
The `FileSystemStoragePathSource` now supports configurable `servable version policy` and reports multiple versions rather than the "latest one version" (which could be incorrect even when the ` servable version policy` is  set as `Latest`).