### PR TITLE
Expose model config files in Docker to serve multiple models

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile
+++ b/tensorflow_serving/tools/docker/Dockerfile
@@ -47,4 +47,9 @@ RUN mkdir -p ${MODEL_BASE_PATH}
 
 # The only required piece is the model name in order to differentiate endpoints
 ENV MODEL_NAME=model
-ENTRYPOINT tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME}
+
+# If non-empty, this config file will be used to specify which model(s) to load
+# (note this will ignore MODEL_NAME and MODEL_BASE_PATH).
+ENV MODEL_CONFIG_FILE=""
+
+ENTRYPOINT tensorflow_model_server --port=8500 --rest_api_port=8501 --model_config_file=${MODEL_CONFIG_FILE} --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME}

--- a/tensorflow_serving/tools/docker/Dockerfile.gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.gpu
@@ -48,4 +48,9 @@ RUN mkdir -p ${MODEL_BASE_PATH}
 
 # The only required piece is the model name in order to differentiate endpoints
 ENV MODEL_NAME=model
-ENTRYPOINT tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME}
+
+# If non-empty, this config file will be used to specify which model(s) to load
+# (note this will ignore MODEL_NAME and MODEL_BASE_PATH).
+ENV MODEL_CONFIG_FILE=""
+
+ENTRYPOINT tensorflow_model_server --port=8500 --rest_api_port=8501 --model_config_file=${MODEL_CONFIG_FILE} --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME}


### PR DESCRIPTION
Expose the --model_config_file argument in the dockerized tensorflow
model server by using an environment variable. The model config file
specifies a list of model(s) and path(s) to use during serving.

This enables a single model server to serve multiple models.

For example, to serve two different MNIST models (A and B), provide a
config file such as this one:

    model_config_list: {
      config: {
        name: "mnistA",
        base_path: "/models/mnistA",
        model_platform: "tensorflow"
      },
      config: {
        name: "mnistB",
        base_path: "/models/mnistB",
        model_platform: "tensorflow"
      }
    }

The model server container can then be started by passing the variable
    -e MODEL_CONFIG_FILE=/models/models.conf

Note: Generally, this is more useful to serve to *separate* models.