### PR TITLE
Fixes #1091 - Support gzip encoded requests

### DIFF
--- a/tensorflow_serving/model_servers/BUILD
+++ b/tensorflow_serving/model_servers/BUILD
@@ -251,6 +251,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_googlesource_code_re2//:re2",
         "@org_tensorflow//tensorflow/core:lib",
+        "@com_github_mapbox_gziphpp//:gzip"
     ],
 )
 

--- a/tensorflow_serving/model_servers/http_server.cc
+++ b/tensorflow_serving/model_servers/http_server.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 
+#include "gzip/decompress.hpp"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
@@ -156,6 +157,12 @@ class RestApiRequestDispatcher {
     string output;
     VLOG(1) << "Processing HTTP request: " << req->http_method() << " "
             << req->uri_path() << " body: " << body.size() << " bytes.";
+
+    if (req->GetRequestHeader("Content-Encoding") == "gzip") {
+      const char * compressed_pointer = body.data();
+      body = gzip::decompress(compressed_pointer, body.size());
+    }
+
     const auto status = handler_->ProcessRequest(
         req->http_method(), req->uri_path(), body, &headers, &output);
     const auto http_status = ToHTTPStatusCode(status);

--- a/tensorflow_serving/workspace.bzl
+++ b/tensorflow_serving/workspace.bzl
@@ -37,6 +37,17 @@ def tf_serving_workspace():
       actual = "@grpc//third_party/nanopb:nanopb",
   )
 
+  # ===== gzip-hpp dependencies ====
+  native.new_http_archive(
+      name = "com_github_mapbox_gziphpp",
+      urls = [
+          "https://github.com/mapbox/gzip-hpp/archive/v0.1.0.zip"
+      ],
+      sha256 = "e44c89ff6fa5ccb99411dad4a6c47fc84efab5bf13970032af5e67de7f6f09dc",
+      strip_prefix = "gzip-hpp-0.1.0",
+      build_file = "third_party/gzip-hpp.BUILD"
+  )
+
   # ===== RapidJSON (rapidjson.org) dependencies =====
   native.new_http_archive(
       name = "com_github_tencent_rapidjson",

--- a/third_party/gzip-hpp.BUILD
+++ b/third_party/gzip-hpp.BUILD
@@ -1,0 +1,14 @@
+# Gzip-hpp (mapbox.com) library.
+# from https://github.com/mapbox/gzip-hpp
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # BSD/MIT.
+
+cc_library(
+    name = "gzip",
+    hdrs = glob(["include/gzip/*.hpp"]),
+    includes = ["include"],
+)


### PR DESCRIPTION
I've never written any C++ nor used Bazel before, so please don't laugh if this is terrible!

I've had a go at supporting gzipped request bodies inside the tensorflow-serving http server: #1091 

I've got no idea if the ticket will be accepted, but I thought it would be fun to have a go at fixing it.

I've also got no idea how to test this, I copied an existing test and made it used zlib (compatible with gzip) to send encoded data.