### PR TITLE
make max_num_load_retries and load_retry_interval_micros configurable for the build-in model_server

### DIFF
--- a/tensorflow_serving/g3doc/docker.md
+++ b/tensorflow_serving/g3doc/docker.md
@@ -447,14 +447,14 @@ To create a serving image that's fully optimized for your host, simply:
 
         ```shell
         docker build --pull -t $USER/tensorflow-serving-devel \
-          -f tools/docker/Dockerfile.devel .
+          -f tensorflow_serving/tools/docker/Dockerfile.devel .
         ```
 
     *   For GPU: `
 
         ```shell
         docker build --pull -t $USER/tensorflow-serving-devel-gpu \
-          -f tools/docker/Dockerfile.devel-gpu .
+          -f tensorflow_serving/tools/docker/Dockerfile.devel-gpu .
         ```
 
 3.  Build a serving image with the development image as a base
@@ -464,7 +464,7 @@ To create a serving image that's fully optimized for your host, simply:
         ```shell
         docker build -t $USER/tensorflow-serving \
           --build-arg TF_SERVING_BUILD_IMAGE=$USER/tensorflow-serving-devel \
-          -f tools/docker/Dockerfile .
+          -f tensorflow_serving/tools/docker/Dockerfile .
         ```
 
         Your new optimized Docker image is now `$USER/tensorflow-serving`, which
@@ -476,7 +476,7 @@ To create a serving image that's fully optimized for your host, simply:
         ```shell
         docker build -t $USER/tensorflow-serving-gpu \
           --build-arg TF_SERVING_BUILD_IMAGE=$USER/tensorflow-serving-devel-gpu \
-          -f tools/docker/Dockerfile.gpu .
+          -f tensorflow_serving/tools/docker/Dockerfile.gpu .
         ```
 
         Your new optimized Docker image is now `$USER/tensorflow-serving-gpu`,

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -88,6 +88,16 @@ int main(int argc, char** argv) {
       tensorflow::Flag("model_base_path", &options.model_base_path,
                        "path to export (ignored if --model_config_file flag "
                        "is set, otherwise required)"),
+      tensorflow::Flag("max_num_load_retries", &options.max_num_load_retries,
+                       "maximum number of times it retries loading a model "
+                       "after the first failure, before giving up. "
+                       "If set to 0, a load is attempted only once. "
+                       "Default: 5"),
+      tensorflow::Flag("load_retry_interval_micros",
+                       &options.load_retry_interval_micros,
+                       "The interval, in microseconds, between each servable "
+                       "load retry. If set negative, it doesn't wait. "
+                       "Default: 1 minute"),
       tensorflow::Flag("file_system_poll_wait_seconds",
                        &options.file_system_poll_wait_seconds,
                        "interval in seconds between each poll of the file "

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -244,6 +244,8 @@ Status Server::BuildAndStart(const Options& server_options) {
   options.custom_model_config_loader = &LoadCustomModelConfig;
   options.aspired_version_policy =
       std::unique_ptr<AspiredVersionPolicy>(new AvailabilityPreservingPolicy);
+  options.max_num_load_retries = server_options.max_num_load_retries;
+  options.load_retry_interval_micros = server_options.load_retry_interval_micros;
   options.file_system_poll_wait_seconds =
       server_options.file_system_poll_wait_seconds;
   options.flush_filesystem_caches = server_options.flush_filesystem_caches;

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -54,6 +54,8 @@ class Server {
     float per_process_gpu_memory_fraction = 0;
     tensorflow::string batching_parameters_file;
     tensorflow::string model_name;
+    tensorflow::int32 max_num_load_retries = 5;
+    tensorflow::int64 load_retry_interval_micros = 1LL * 60 * 1000 * 1000;
     tensorflow::int32 file_system_poll_wait_seconds = 1;
     bool flush_filesystem_caches = true;
     tensorflow::string model_base_path;

--- a/tensorflow_serving/model_servers/server_core.cc
+++ b/tensorflow_serving/model_servers/server_core.cc
@@ -658,6 +658,7 @@ Status ServerCore::CreateAspiredVersionsManager(
   manager_options.num_load_threads = options_.num_load_threads;
   manager_options.num_unload_threads = options_.num_unload_threads;
   manager_options.max_num_load_retries = options_.max_num_load_retries;
+  manager_options.load_retry_interval_micros = options_.load_retry_interval_micros;
   manager_options.pre_load_hook = std::move(options_.pre_load_hook);
   manager_options.flush_filesystem_caches = options_.flush_filesystem_caches;
   const tensorflow::Status status =

--- a/tensorflow_serving/model_servers/server_core.h
+++ b/tensorflow_serving/model_servers/server_core.h
@@ -113,7 +113,14 @@ class ServerCore : public Manager {
 
     // Maximum number of times we retry loading a model, after the first
     // failure, before we give up.
+    //
+    // If set to 0, a load is attempted only once.
     int32 max_num_load_retries = 5;
+
+    // The interval, in microseconds, between each servable load retry. If set
+    // negative, we don't wait.
+    // Default: 1 minute.
+    int64 load_retry_interval_micros = 1LL * 60 * 1000 * 1000;
 
     // Time interval between file-system polls, in seconds.
     int32 file_system_poll_wait_seconds = 30;


### PR DESCRIPTION
- exposed `max_num_load_retries ` and `load_retry_interval_micros` as flags of ModelServer
- fixed wrong docker file path at docker readme 

solved https://github.com/tensorflow/serving/issues/1099