### PR TITLE
Add descriptive error messages for invalid json for REST requests

### DIFF
--- a/tensorflow_serving/util/json_tensor_test.cc
+++ b/tensorflow_serving/util/json_tensor_test.cc
@@ -509,7 +509,7 @@ TEST(JsontensorTest, SingleUnnamedTensorErrors) {
     })",
                                       getmap(infomap), &req, &format);
   ASSERT_TRUE(errors::IsInvalidArgument(status));
-  EXPECT_THAT(status.error_message(), HasSubstr("not formatted correctly"));
+  EXPECT_THAT(status.error_message(), HasSubstr("Not formatted correctly"));
 
   status = FillPredictRequestFromJson(R"(
     {


### PR DESCRIPTION
Add error messages for specific cases when json for REST requests is not formatted correctly to assist in debugging calls. Previously
    error messages return the same error message for
     * Both inputs and instances existed
     * Value was not an array when array expected
     * Empty array
     * When examples key was missing for method classify

This is an minor issue I had during debugging and noticed one stackoverflow as well
https://stackoverflow.com/questions/52534843/how-to-use-predict-api-of-tensorflow-serving
https://stackoverflow.com/questions/51776489/correct-payload-for-tensorflow-serving-rest-api
