### PR TITLE
Add support for listening gRPC over UNIX socket

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -59,6 +59,10 @@ int main(int argc, char** argv) {
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("port", &options.grpc_port,
                        "Port to listen on for gRPC API"),
+      tensorflow::Flag("grpc_socket_path", &options.grpc_socket_path,
+                       "If non-empty, listen to a UNIX socket for gRPC API "
+                       "on the given path. Can be either relative or absolute "
+                       "path."),
       tensorflow::Flag("rest_api_port", &options.http_port,
                        "Port to listen on for HTTP/REST API. If set to zero "
                        "HTTP/REST API will not be exported. This port must be "

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -293,7 +293,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
   if (!server_options.grpc_socket_path.empty()) {
     LOG(INFO) << "Running gRPC ModelServer at UNIX socket "
-              << server_options.grpc_socket_path << "...";
+              << server_options.grpc_socket_path << " ...";
   }
 
   if (server_options.http_port != 0) {

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -264,9 +264,8 @@ Status Server::BuildAndStart(const Options& server_options) {
       server_address,
       BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
   // If defined, listen to a UNIX socket for gRPC.
-  const string grpc_socket_path = server_options.grpc_socket_path;
-  const string grpc_socket_uri = "unix:" + grpc_socket_path;
-  if (!grpc_socket_path.empty()) {
+  if (!server_options.grpc_socket_path.empty()) {
+    const string grpc_socket_uri = "unix:" + server_options.grpc_socket_path;
     builder.AddListeningPort(
       grpc_socket_uri,
       BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
@@ -292,9 +291,9 @@ Status Server::BuildAndStart(const Options& server_options) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
   LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
-  if (!grpc_socket_path.empty()) {
+  if (!server_options.grpc_socket_path.empty()) {
     LOG(INFO) << "Running gRPC ModelServer at UNIX socket "
-              << grpc_socket_uri << "...";
+              << server_options.grpc_socket_path << "...";
   }
 
   if (server_options.http_port != 0) {

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -263,6 +263,14 @@ Status Server::BuildAndStart(const Options& server_options) {
   builder.AddListeningPort(
       server_address,
       BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  // If defined, listen to a UNIX socket for gRPC.
+  const string grpc_socket_path = server_options.grpc_socket_path;
+  const string grpc_socket_uri = "unix:" + grpc_socket_path;
+  if (!grpc_socket_path.empty()) {
+    builder.AddListeningPort(
+      grpc_socket_uri,
+      BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  }
   builder.RegisterService(model_service_.get());
   builder.RegisterService(prediction_service_.get());
   builder.SetMaxMessageSize(tensorflow::kint32max);
@@ -284,6 +292,10 @@ Status Server::BuildAndStart(const Options& server_options) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
   LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
+  if (!grpc_socket_path.empty()) {
+    LOG(INFO) << "Running gRPC ModelServer at UNIX socket "
+              << grpc_socket_uri << "...";
+  }
 
   if (server_options.http_port != 0) {
     if (server_options.http_port != server_options.grpc_port) {

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -39,6 +39,7 @@ class Server {
     //
     tensorflow::int32 grpc_port = 8500;
     tensorflow::string grpc_channel_arguments;
+    tensorflow::string grpc_socket_path;
 
     //
     // HTTP Server options.


### PR DESCRIPTION
One typical deployment model for Tensorflow Serving is to run it as a sidecar container. With this approach the model is often served over HTTP through a loopback interface. For performance reasons it would make sense to offer a possibility to access Serving over UNIX sockets. This would remove TCP overhead and reduce context switching.

This PR adds a new CLI flag `--grpc_socket_path`. If defined, Serving will listen to a UNIX domain socket at this path. It can be a relative or an absolute path. Note that abstract UNIX sockets are not supported with gRPC. There is an issue about this at https://github.com/grpc/grpc/issues/4677.