### PR TITLE
Server support for modelconf monitoring and model(s) load/unload

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -102,6 +102,10 @@ int main(int argc, char** argv) {
                        &options.file_system_poll_wait_seconds,
                        "interval in seconds between each poll of the file "
                        "system for new model version"),
+      tensorflow::Flag("modelconf_poll_wait_seconds",
+                       &options.modelconf_poll_wait_seconds,
+                       "activates model_config_file monitor in seconds; "
+                       "if change is detected, models will be Added/updated; default=0 (disabled)"),
       tensorflow::Flag("flush_filesystem_caches",
                        &options.flush_filesystem_caches,
                        "If true (the default), filesystem caches will be "


### PR DESCRIPTION
This will make model server to monitor for any changes inside modelconf proto file; if new model type is added, it will load those that were added; similarly if something is removed, it will unload those.
The new server parameter is: modelconf_poll_wait_seconds, which defaults to 0. This function will Not be activated unless a value greater than 0 is supplied during server startup. If value greater than 0 is given, the monitor will start and perform its function at specified frequency in seconds. 