### PR TITLE
Modelconf auto-manager 

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -102,6 +102,10 @@ int main(int argc, char** argv) {
                        &options.file_system_poll_wait_seconds,
                        "interval in seconds between each poll of the file "
                        "system for new model version"),
+      tensorflow::Flag("modelconf_poll_wait_seconds",
+                       &options.modelconf_poll_wait_seconds,
+                       "activates model_config_file monitor in seconds; "
+                       "if change is detected, models will be Added/updated; default=0 (disabled)"),
       tensorflow::Flag("flush_filesystem_caches",
                        &options.flush_filesystem_caches,
                        "If true (the default), filesystem caches will be "

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -175,7 +175,7 @@ Server::~Server() { WaitForTermination(); }
 
 std::atomic<bool> Server::model_conf_mon_thread_exit_(false);
 
-int Server::model_config_mon_thread_function(std::unique_ptr<ServerCore> core_p, const string& model_conf_file,
+int Server::model_config_mon_thread_function(ServerCore* core_p, const string& model_conf_file,
                                              tensorflow::int32 modelconf_poll_wait_seconds) {
 
   LOG(INFO) << "Enter model_config_mon_thread_function";
@@ -311,7 +311,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   if (server_options.modelconf_poll_wait_seconds > 0) {
     LOG(INFO) << "Starting modelconf monitor ";
     model_conf_mon_thread_ = std::unique_ptr<std::thread>(new std::thread(&Server::model_config_mon_thread_function,
-                                                                          std::move(server_core_),
+                                                                          server_core_.get(),
                                                                           server_options.model_config_file,
                                                                           server_options.modelconf_poll_wait_seconds));
   }

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -87,7 +87,7 @@ class Server {
   // This will block the current thread until termination is successful.
   void WaitForTermination();
 
-  static int model_config_mon_thread_function(std::unique_ptr<ServerCore> core_p, const string& model_conf_file,
+  static int model_config_mon_thread_function(ServerCore* core_p, const string& model_conf_file,
                                               tensorflow::int32 modelconf_poll_wait_seconds);
 
  private:


### PR DESCRIPTION
This will make model server to monitor for any changes inside modelconf proto file; if new model type is added, it will load those that were added; similarly if something is removed, it will unload those.
The new server parameter is: modelconf_poll_wait_seconds, which defaults to 0. This function will Not be activated unless a value greater than 0 is supplied during server startup. If value greater than 0 is given, the monitor will start and perform its function at specified frequency in seconds.