### PR TITLE
Need space after curl `filename`

### DIFF
--- a/tensorflow_serving/g3doc/serving_kubernetes.md
+++ b/tensorflow_serving/g3doc/serving_kubernetes.md
@@ -35,7 +35,7 @@ for the ImageNet dataset.
 
 ```shell
 mkdir /tmp/resnet
-curl -s http://download.tensorflow.org/models/official/20181001_resnet/savedmodels/resnet_v2_fp32_savedmodel_NHWC_jpg.tar.gz| \
+curl -s http://download.tensorflow.org/models/official/20181001_resnet/savedmodels/resnet_v2_fp32_savedmodel_NHWC_jpg.tar.gz | \
 tar --strip-components=2 -C /tmp/resnet -xvz
 ```
 


### PR DESCRIPTION
Added space to bash command to allow for copy pasting