### PR TITLE
Update the tutorial code snippet to match the latest mnist_saved_model.py

### DIFF
--- a/tensorflow_serving/g3doc/serving_basic.md
+++ b/tensorflow_serving/g3doc/serving_basic.md
@@ -60,7 +60,7 @@ builder.add_meta_graph_and_variables(
            signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY:
                classification_signature,
       },
-      main_op=main_op)
+      main_op=tf.tables_initializer())
 builder.save()
 ```
 


### PR DESCRIPTION
According to the warning message (line 90) in mnist_saved_model.py, the code snippet in the tutorial should be kept up-to-date. The original line in the tutorial code snippet also creates confusion.