### PR TITLE
Making resnet_client.py python3 compliant:

### DIFF
--- a/tensorflow_serving/example/resnet_client.py
+++ b/tensorflow_serving/example/resnet_client.py
@@ -48,18 +48,18 @@ def main():
   dl_request.raise_for_status()
 
   # Compose a JSON Predict request (send JPEG image in base64).
-  predict_request = '{"instances" : [{"b64": "%s"}]}' % base64.b64encode(
+  predict_request = b'{"instances" : [{"b64": "%s"}]}' % base64.b64encode(
       dl_request.content)
 
   # Send few requests to warm-up the model.
-  for _ in xrange(3):
+  for _ in range(3):
     response = requests.post(SERVER_URL, data=predict_request)
     response.raise_for_status()
 
   # Send few actual requests and report average latency.
   total_time = 0
   num_requests = 10
-  for _ in xrange(num_requests):
+  for _ in range(num_requests):
     response = requests.post(SERVER_URL, data=predict_request)
     response.raise_for_status()
     total_time += response.elapsed.total_seconds()


### PR DESCRIPTION
I did not manage to use  the resnet_client.py example with python 3.
I suggest the following modification so the file is also python3 compliant:

1. Using a bytes-like object in the base64.b64encode() method
2. Modified xrange=>range. 'xrange' keyword is not python3 complient and a generator is not required for such short sequence.