### PR TITLE
Fix typo in usage message

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
                        "used, --model_name, --model_base_path are ignored.)"),
       tensorflow::Flag("model_name", &options.model_name,
                        "name of model (ignored "
-                       "if --model_config_file flag is set"),
+                       "if --model_config_file flag is set)"),
       tensorflow::Flag("model_base_path", &options.model_base_path,
                        "path to export (ignored if --model_config_file flag "
                        "is set, otherwise required)"),


### PR DESCRIPTION
I think there is an un-closed parenthesis in the usage message for `--model_name`.