### PR TITLE
[FEATURE]: Split tensorflow_session_parallelism for optimal performance

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -121,6 +121,18 @@ int main(int argc, char** argv) {
                        "Tensorflow session. Auto-configured by default."
                        "Note that this option is ignored if "
                        "--platform_config_file is non-empty."),
+      tensorflow::Flag("tensorflow_intra_op_parallelism",
+                       &options.tensorflow_intra_op_parallelism,
+                       "Number of threads to use to parallelize the execution"
+                       "of an individual op. Auto-configured by default."
+                       "Note that this option is ignored if "
+                       "--platform_config_file is non-empty."),
+      tensorflow::Flag("tensorflow_inter_op_parallelism",
+                       &options.tensorflow_inter_op_parallelism,
+                       "Controls the number of operators that can be executed "
+                       "simultaneously. Auto-configured by default."
+                       "Note that this option is ignored if "
+                       "--platform_config_file is non-empty."),
       tensorflow::Flag(
           "ssl_config_file", &options.ssl_config_file,
           "If non-empty, read an ascii SSLConfig protobuf from "

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -64,6 +64,10 @@ class Server {
     // Tensorflow session parallelism of zero means that both inter and intra op
     // thread pools will be auto configured.
     tensorflow::int64 tensorflow_session_parallelism = 0;
+
+    // Zero means that the thread pools will be auto configured.
+    tensorflow::int64 tensorflow_intra_op_parallelism = 0;
+    tensorflow::int64 tensorflow_inter_op_parallelism = 0;
     tensorflow::string platform_config_file;
     tensorflow::string ssl_config_file;
     string model_config_file;

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
@@ -77,7 +77,6 @@ RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tenso
     git remote add upstream https://github.com/tensorflow/serving.git && \
     if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
 
-
 FROM base_build as binary_build
 
 # Build, and install TensorFlow Serving

--- a/tensorflow_serving/tools/docker/Dockerfile.mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.mkl
@@ -81,21 +81,18 @@ ENV KMP_SETTINGS=1
 ENV KMP_AFFINITY='granularity=fine,verbose,compact,1,0'
 ENV MKLDNN_VERBOSE=0
 
-# You can set either TENSORFLOW_SESSION_PARALLELISM or
-# TENSORFLOW_INTRA_OP_PARALLELISM and TENSORFLOW_INTER_OP_PARALLELISM envs separately.
-# Please comment or uncomment as required.
-# If you want to set TENSORFLOW_SESSION_PARALLELISM, uncomment respective env and line in bash script below
-# and comment out TENSORFLOW_INTRA_OP_PARALLELISM and TENSORFLOW_INTER_OP_PARALLELISM along with respective
-# lines in below bash script.
+# Recommended settings, may vary depending on the model.
+# Set TENSORFLOW_INTRA_OP_PARALLELISM=#No.of Physical cores
+# Set TENSORFLOW_INTER_OP_PARALLELISM=#No.of Sockets
+# For more information vist below reference
+# https://www.tensorflow.org/guide/performance/overview#tuning_mkl_for_the_best_performance
 
-#ENV TENSORFLOW_SESSION_PARALLELISM=2
-
+# Defaults
 ENV TENSORFLOW_INTRA_OP_PARALLELISM=2
 ENV TENSORFLOW_INTER_OP_PARALLELISM=2
 
 RUN echo '#!/bin/bash \n\n\
 tensorflow_model_server --port=8500 --rest_api_port=8501 \
-#--tensorflow_session_parallelism=${TENSORFLOW_SESSION_PARALLELISM} \
 --tensorflow_intra_op_parallelism=${TENSORFLOW_INTRA_OP_PARALLELISM} \
 --tensorflow_inter_op_parallelism=${TENSORFLOW_INTER_OP_PARALLELISM} \
 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \

--- a/tensorflow_serving/tools/docker/Dockerfile.mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.mkl
@@ -81,11 +81,23 @@ ENV KMP_SETTINGS=1
 ENV KMP_AFFINITY='granularity=fine,verbose,compact,1,0'
 ENV MKLDNN_VERBOSE=0
 
-ENV TENSORFLOW_SESSION_PARALLELISM=2
+# You can set either TENSORFLOW_SESSION_PARALLELISM or
+# TENSORFLOW_INTRA_OP_PARALLELISM and TENSORFLOW_INTER_OP_PARALLELISM envs separately.
+# Please comment or uncomment as required.
+# If you want to set TENSORFLOW_SESSION_PARALLELISM, uncomment respective env and line in bash script below
+# and comment out TENSORFLOW_INTRA_OP_PARALLELISM and TENSORFLOW_INTER_OP_PARALLELISM along with respective
+# lines in below bash script.
+
+#ENV TENSORFLOW_SESSION_PARALLELISM=2
+
+ENV TENSORFLOW_INTRA_OP_PARALLELISM=2
+ENV TENSORFLOW_INTER_OP_PARALLELISM=2
 
 RUN echo '#!/bin/bash \n\n\
 tensorflow_model_server --port=8500 --rest_api_port=8501 \
---tensorflow_session_parallelism=${TENSORFLOW_SESSION_PARALLELISM} \
+#--tensorflow_session_parallelism=${TENSORFLOW_SESSION_PARALLELISM} \
+--tensorflow_intra_op_parallelism=${TENSORFLOW_INTRA_OP_PARALLELISM} \
+--tensorflow_inter_op_parallelism=${TENSORFLOW_INTER_OP_PARALLELISM} \
 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
 "$@"' > /usr/bin/tf_serving_entrypoint.sh \
 && chmod +x /usr/bin/tf_serving_entrypoint.sh


### PR DESCRIPTION
Related to #1237 

This PR will add new flags `tensorflow_inter_op_parallelism` and `tensorflow_intra_op_parallelism` to configure values separately. 

To avoid any issues still we support backward compatibility for `tensorflow_session_parallelism`.

Logic goes as below

if either `tensorflow_inter_op_parallelism` OR `tensorflow_intra_op_parallelism` are set, then use those values and ignore `tensorflow_session_parallelism`; if `tensorflow_session_parallelism` is set as well, generate a error message. If neither `tensorflow_inter_op_parallelism` or `tensorflow_intra_op_parallelism` is set, then use `tensorflow_session_parallelism`.

**NOTE:** we'd like the single `tensorflow_session_parallelism` variable to be deprecated in favor of the two `tensorflow_inter_op_parallelism` and `tensorflow_intra_op_parallelism` variables that TensorFlow supports. 

Please let us know your thoughts.