### PR TITLE
Fix version matching

### DIFF
--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -33,7 +33,7 @@ DOCLINES = __doc__.split('\n')
 # Set when releasing a new version of TensorFlow Serving (e.g. 1.0.0).
 _VERSION = '1.14.0-rc0'
 # Have this by default be open; releasing a new version will lock to TF version
-_TF_VERSION = '=1.14.0-rc0'
+_TF_VERSION = '===1.14.0-rc0'
 _TF_VERSION_SANITIZED = _TF_VERSION.replace('-', '')
 
 project_name = 'tensorflow-serving-api'


### PR DESCRIPTION
Use `===` operator for version matching as `=` only supports numbers.