### PR TITLE
Fixed latest master build

### DIFF
--- a/tensorflow_serving/util/net_http/internal/BUILD
+++ b/tensorflow_serving/util/net_http/internal/BUILD
@@ -25,6 +25,6 @@ cc_library(
     deps = [
         "@com_google_absl//absl/base:config",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/base:log_severity",
+        "@com_google_absl//absl/base:base",
     ],
 )


### PR DESCRIPTION
There was a build failure due to latest commit 4e12a193ad27fa31cb1e42e9a7fe7b5c08f74c52. 
Error -
ERROR: serving/util/net_http/internal/BUILD:21:1: no such target '@com_google_absl//absl/base:log_severity': target 'log_severity' not declared in package 'absl/base' (did you mean 'log_severity.h'?) defined by $HOME/.cache/bazel/_bazel_builder/6b497cc2f6dec0e272a99e426a69bdc6/external/com_google_absl/absl/base/BUILD.bazel and referenced by '//tensorflow_serving/util/net_http/internal:net_logging'

This PR fixes the above error.