### PR TITLE
Add shift to consume script name before passing to application

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile
+++ b/tensorflow_serving/tools/docker/Dockerfile
@@ -51,6 +51,7 @@ ENV MODEL_NAME=model
 # Create a script that runs the model server so we can use environment variables
 # while also passing in arguments from the docker command line
 RUN echo '#!/bin/bash \n\n\
+shift \n\
 tensorflow_model_server --port=8500 --rest_api_port=8501 \
 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
 "$@"' > /usr/bin/tf_serving_entrypoint.sh \


### PR DESCRIPTION
The Dockerfile entrypoint /usr/bin/tf_serving_entrypoint.sh calls tensorflow_model_server with "$@" which results in an error message from tensorflow_model_server that "/usr/bin/tf_serving_entrypoint.sh" is not a supported option. This is because "$@" passes the first parameter which is the name of the script itself. To resolve this simply add the shift command to consume the first argument and then pass "$@" to tensorflow_model_server.