### PR TITLE
Fix typo in REQUIRED_PACKAGES for grpcio

### DIFF
--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -53,7 +53,7 @@ if 'tensorflow-serving-api-gpu' in project_name:
 
 
 REQUIRED_PACKAGES = [
-    'grpcio>=1.0<2',
+    'grpcio>=1.0,<2',
     'protobuf>=3.6.0',
 ] + _TF_REQ
 


### PR DESCRIPTION
Replace `grpcio>=1.0<2` with `grpcio>=1.0,<2`
This typo makes `conda env export` crash.