### PR TITLE
remove obsolete method call from python example

### DIFF
--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -146,7 +146,7 @@ def do_inference(hostport, work_dir, concurrency, num_tests):
     request.model_spec.signature_name = 'predict_images'
     image, label = test_data_set.next_batch(1)
     request.inputs['images'].CopyFrom(
-        tf.contrib.util.make_tensor_proto(image[0], shape=[1, image[0].size]))
+        tf.make_tensor_proto(image[0], shape=[1, image[0].size]))
     result_counter.throttle()
     result_future = stub.Predict.future(request, 5.0)  # 5 seconds
     result_future.add_done_callback(


### PR DESCRIPTION
The other Tensorflow Serving Python examples are still broken.

This and other issues are addressed in the below issue.
Ref: https://github.com/tensorflow/serving/issues/1475

