### PR TITLE
fixed small error in predict request example

### DIFF
--- a/tensorflow_serving/g3doc/tutorials/Serving_REST_simple.ipynb
+++ b/tensorflow_serving/g3doc/tutorials/Serving_REST_simple.ipynb
@@ -504,7 +504,7 @@
         "predictions = json.loads(json_response.text)['predictions']\n",
         "\n",
         "show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-        "  class_names[np.argmax(predictions[0])], test_labels[0], class_names[np.argmax(predictions[0])], test_labels[0]))"
+        "  class_names[np.argmax(predictions[0])], np.argmax(predictions[0]), class_names[test_labels[0]], test_labels[0]))"
       ]
     },
     {


### PR DESCRIPTION
Found a small error in this tutorial example.  Looks like 3870ba59a764d859fc137a8363588c94906e0f5f fixed a similar error recently, but it occurred in two places.