### PR TITLE
use compat.v1 in examples

### DIFF
--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -41,12 +41,12 @@ from tensorflow_serving.apis import prediction_service_pb2_grpc
 import mnist_input_data
 
 
-tf.app.flags.DEFINE_integer('concurrency', 1,
+tf.compat.v1.app.flags.DEFINE_integer('concurrency', 1,
                             'maximum number of concurrent inference requests')
-tf.app.flags.DEFINE_integer('num_tests', 100, 'Number of test images')
-tf.app.flags.DEFINE_string('server', '', 'PredictionService host:port')
-tf.app.flags.DEFINE_string('work_dir', '/tmp', 'Working directory. ')
-FLAGS = tf.app.flags.FLAGS
+tf.compat.v1.app.flags.DEFINE_integer('num_tests', 100, 'Number of test images')
+tf.compat.v1.app.flags.DEFINE_string('server', '', 'PredictionService host:port')
+tf.compat.v1.app.flags.DEFINE_string('work_dir', '/tmp', 'Working directory. ')
+FLAGS = tf.compat.v1.app.flags.FLAGS
 
 
 class _ResultCounter(object):
@@ -146,7 +146,7 @@ def do_inference(hostport, work_dir, concurrency, num_tests):
     request.model_spec.signature_name = 'predict_images'
     image, label = test_data_set.next_batch(1)
     request.inputs['images'].CopyFrom(
-        tf.contrib.util.make_tensor_proto(image[0], shape=[1, image[0].size]))
+        tf.make_tensor_proto(image[0], shape=[1, image[0].size]))
     result_counter.throttle()
     result_future = stub.Predict.future(request, 5.0)  # 5 seconds
     result_future.add_done_callback(
@@ -167,4 +167,4 @@ def main(_):
 
 
 if __name__ == '__main__':
-  tf.app.run()
+  tf.compat.v1.app.run()

--- a/tensorflow_serving/example/mnist_saved_model.py
+++ b/tensorflow_serving/example/mnist_saved_model.py
@@ -36,6 +36,7 @@ import tensorflow as tf
 
 import mnist_input_data
 
+tf.compat.v1.disable_eager_execution()
 tf.compat.v1.flags.DEFINE_integer('training_iteration', 1000,
                             'number of training iterations.')
 tf.compat.v1.flags.DEFINE_integer('model_version', 1, 'version number of the model.')
@@ -58,22 +59,22 @@ def main(_):
   # Train model
   print('Training model...')
   mnist = mnist_input_data.read_data_sets(FLAGS.work_dir, one_hot=True)
-  sess = tf.InteractiveSession()
-  serialized_tf_example = tf.placeholder(tf.string, name='tf_example')
-  feature_configs = {'x': tf.FixedLenFeature(shape=[784], dtype=tf.float32),}
-  tf_example = tf.parse_example(serialized_tf_example, feature_configs)
+  sess = tf.compat.v1.InteractiveSession()
+  serialized_tf_example = tf.compat.v1.placeholder(tf.string, name='tf_example')
+  feature_configs = {'x': tf.compat.v1.FixedLenFeature(shape=[784], dtype=tf.float32),}
+  tf_example = tf.compat.v1.parse_example(serialized_tf_example, feature_configs)
   x = tf.identity(tf_example['x'], name='x')  # use tf.identity() to assign name
-  y_ = tf.placeholder('float', shape=[None, 10])
+  y_ = tf.compat.v1.placeholder('float', shape=[None, 10])
   w = tf.Variable(tf.zeros([784, 10]))
   b = tf.Variable(tf.zeros([10]))
-  sess.run(tf.global_variables_initializer())
+  sess.run(tf.compat.v1.global_variables_initializer())
   y = tf.nn.softmax(tf.matmul(x, w) + b, name='y')
-  cross_entropy = -tf.reduce_sum(y_ * tf.log(y))
-  train_step = tf.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
+  cross_entropy = -tf.reduce_sum(y_ * tf.compat.v1.log(y))
+  train_step = tf.compat.v1.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
   values, indices = tf.nn.top_k(y, 10)
-  table = tf.contrib.lookup.index_to_string_table_from_tensor(
-      tf.constant([str(i) for i in range(10)]))
-  prediction_classes = table.lookup(tf.to_int64(indices))
+#  table = tf.compat.v1.contrib.lookup.index_to_string_table_from_tensor(
+#      tf.constant([str(i) for i in range(10)]))
+#  prediction_classes = table.lookup(tf.to_int64(indices))
   for _ in range(FLAGS.training_iteration):
     batch = mnist.train.next_batch(50)
     train_step.run(feed_dict={x: batch[0], y_: batch[1]})
@@ -95,47 +96,47 @@ def main(_):
       tf.compat.as_bytes(export_path_base),
       tf.compat.as_bytes(str(FLAGS.model_version)))
   print('Exporting trained model to', export_path)
-  builder = tf.saved_model.builder.SavedModelBuilder(export_path)
+  builder = tf.compat.v1.saved_model.builder.SavedModelBuilder(export_path)
 
   # Build the signature_def_map.
-  classification_inputs = tf.saved_model.utils.build_tensor_info(
+  classification_inputs = tf.compat.v1.saved_model.utils.build_tensor_info(
       serialized_tf_example)
-  classification_outputs_classes = tf.saved_model.utils.build_tensor_info(
-      prediction_classes)
-  classification_outputs_scores = tf.saved_model.utils.build_tensor_info(values)
+  classification_outputs_classes = tf.compat.v1.saved_model.utils.build_tensor_info(
+      indices)
+  classification_outputs_scores = tf.compat.v1.saved_model.utils.build_tensor_info(values)
 
   classification_signature = (
-      tf.saved_model.signature_def_utils.build_signature_def(
+      tf.compat.v1.saved_model.signature_def_utils.build_signature_def(
           inputs={
-              tf.saved_model.signature_constants.CLASSIFY_INPUTS:
+              tf.compat.v1.saved_model.signature_constants.CLASSIFY_INPUTS:
                   classification_inputs
           },
           outputs={
-              tf.saved_model.signature_constants.CLASSIFY_OUTPUT_CLASSES:
+              tf.compat.v1.saved_model.signature_constants.CLASSIFY_OUTPUT_CLASSES:
                   classification_outputs_classes,
-              tf.saved_model.signature_constants.CLASSIFY_OUTPUT_SCORES:
+              tf.compat.v1.saved_model.signature_constants.CLASSIFY_OUTPUT_SCORES:
                   classification_outputs_scores
           },
-          method_name=tf.saved_model.signature_constants.CLASSIFY_METHOD_NAME))
+          method_name=tf.compat.v1.saved_model.signature_constants.CLASSIFY_METHOD_NAME))
 
-  tensor_info_x = tf.saved_model.utils.build_tensor_info(x)
-  tensor_info_y = tf.saved_model.utils.build_tensor_info(y)
+  tensor_info_x = tf.compat.v1.saved_model.utils.build_tensor_info(x)
+  tensor_info_y = tf.compat.v1.saved_model.utils.build_tensor_info(y)
 
   prediction_signature = (
-      tf.saved_model.signature_def_utils.build_signature_def(
+      tf.compat.v1.saved_model.signature_def_utils.build_signature_def(
           inputs={'images': tensor_info_x},
           outputs={'scores': tensor_info_y},
-          method_name=tf.saved_model.signature_constants.PREDICT_METHOD_NAME))
+          method_name=tf.compat.v1.saved_model.signature_constants.PREDICT_METHOD_NAME))
 
   builder.add_meta_graph_and_variables(
-      sess, [tf.saved_model.tag_constants.SERVING],
+      sess, [tf.compat.v1.saved_model.tag_constants.SERVING],
       signature_def_map={
           'predict_images':
               prediction_signature,
-          tf.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY:
+          tf.compat.v1.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY:
               classification_signature,
       },
-      main_op=tf.tables_initializer(),
+      main_op=tf.compat.v1.tables_initializer(),
       strip_default_attrs=True)
 
   builder.save()

--- a/tensorflow_serving/example/mnist_saved_model.py
+++ b/tensorflow_serving/example/mnist_saved_model.py
@@ -36,11 +36,11 @@ import tensorflow as tf
 
 import mnist_input_data
 
-tf.app.flags.DEFINE_integer('training_iteration', 1000,
+tf.compat.v1.flags.DEFINE_integer('training_iteration', 1000,
                             'number of training iterations.')
-tf.app.flags.DEFINE_integer('model_version', 1, 'version number of the model.')
-tf.app.flags.DEFINE_string('work_dir', '/tmp', 'Working directory.')
-FLAGS = tf.app.flags.FLAGS
+tf.compat.v1.flags.DEFINE_integer('model_version', 1, 'version number of the model.')
+tf.compat.v1.flags.DEFINE_string('work_dir', '/tmp', 'Working directory.')
+FLAGS = tf.compat.v1.flags.FLAGS
 
 
 def main(_):
@@ -144,4 +144,4 @@ def main(_):
 
 
 if __name__ == '__main__':
-  tf.app.run()
+  tf.compat.v1.app.run()


### PR DESCRIPTION
Following the example per (https://www.tensorflow.org/tfx/serving/serving_basic) results in the following error:

```
-> % rm -rf /tmp/mnist
-> % tools/run_in_docker.sh python tensorflow_serving/example/mnist_saved_model.py /tmp/mnist
== Pulling docker image: tensorflow/serving:nightly-devel
nightly-devel: Pulling from tensorflow/serving
7ddbc47eeb70: Pull complete
c1bbdc448b72: Pull complete
8c3b70e39044: Pull complete
45d437916d57: Pull complete
761eda96e661: Pull complete
a1b3c36f2fa2: Pull complete
6d8d8654b44d: Pull complete
62d7bd5ff8df: Pull complete
976fdd344e03: Pull complete
b7f28967e9bf: Pull complete
4a092ac5dea5: Pull complete
10546539adb2: Pull complete
22829b62ad91: Pull complete
Digest: sha256:6d46002d44521303961d988bfc92eeeaea9a69f3c1892f8b5d9a426dbcb44c9d
Status: Downloaded newer image for tensorflow/serving:nightly-devel
== Running cmd: sh -c 'cd /Users/schiff/Documents/tensorflow-serving; python tensorflow_serving/example/mnist_saved_model.py /tmp/mnist'
Traceback (most recent call last):
  File "tensorflow_serving/example/mnist_saved_model.py", line 39, in <module>
    tf.app.flags.DEFINE_integer('training_iteration', 1000,
AttributeError: 'module' object has no attribute 'app'
```