### PR TITLE
Don't unload versions in config under specific-version policy when the version directory missed.

### DIFF
--- a/tensorflow_serving/core/BUILD
+++ b/tensorflow_serving/core/BUILD
@@ -654,6 +654,8 @@ cc_library(
         ":loader_harness",
         ":servable_id",
         "//tensorflow_serving/util:optional",
+        "//tensorflow_serving/sources/storage_path:file_system_storage_path_source",
+        "//tensorflow_serving/sources/storage_path:file_system_storage_path_source_proto",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )

--- a/tensorflow_serving/core/aspired_version_policy.cc
+++ b/tensorflow_serving/core/aspired_version_policy.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <unordered_set>
+
 #include "tensorflow_serving/core/aspired_version_policy.h"
 
 namespace tensorflow {
@@ -30,6 +32,17 @@ optional<ServableId> AspiredVersionPolicy::GetHighestAspiredNewServableId(
     }
   }
   return highest_version_id;
+}
+
+std::unordered_set<int64>
+AspiredVersionPolicy::GetConfiguringSpecificVersions(
+    const std::string& servable_name) const {
+  mutex_lock l(mu_);
+  if (storage_path_source_ == nullptr) {
+    std::unordered_set<int64> empty_set;
+    return empty_set;
+  }
+  return storage_path_source_->GetConfiguringSpecificVersions(servable_name);
 }
 
 }  // namespace serving

--- a/tensorflow_serving/core/aspired_version_policy.h
+++ b/tensorflow_serving/core/aspired_version_policy.h
@@ -18,12 +18,14 @@ limitations under the License.
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow_serving/core/loader_harness.h"
 #include "tensorflow_serving/core/servable_id.h"
 #include "tensorflow_serving/util/optional.h"
+#include "tensorflow_serving/sources/storage_path/file_system_storage_path_source.h"
 
 namespace tensorflow {
 namespace serving {
@@ -78,6 +80,15 @@ class AspiredVersionPolicy {
   virtual optional<ServableAction> GetNextAction(
       const std::vector<AspiredServableStateSnapshot>& all_versions) const = 0;
 
+  void set_storage_path_source(
+      FileSystemStoragePathSource* storage_path_source) {
+    mutex_lock l(mu_);
+    storage_path_source_ = storage_path_source;
+  }
+
+  std::unordered_set<int64> GetConfiguringSpecificVersions(
+      const std::string& servable_name) const;
+
  protected:
   /// Returns the aspired ServableId with the highest version that matches
   /// kNew state, if any exists.
@@ -86,6 +97,8 @@ class AspiredVersionPolicy {
 
  private:
   friend class AspiredVersionPolicyTest;
+  mutable mutex mu_;
+  FileSystemStoragePathSource* storage_path_source_ GUARDED_BY(mu_) = nullptr ;
 };
 
 inline bool operator==(const AspiredVersionPolicy::ServableAction& lhs,

--- a/tensorflow_serving/core/aspired_versions_manager.h
+++ b/tensorflow_serving/core/aspired_versions_manager.h
@@ -204,6 +204,11 @@ class AspiredVersionsManager : public Manager,
   Source<std::unique_ptr<Loader>>::AspiredVersionsCallback
   GetAspiredVersionsCallback() override;
 
+  void SetPolicyStoragePathSource(
+      FileSystemStoragePathSource* storage_path_source) {
+    aspired_version_policy_->set_storage_path_source(storage_path_source);
+  }
+
  private:
   friend class internal::AspiredVersionsManagerTargetImpl;
   friend class test_util::AspiredVersionsManagerTestAccess;

--- a/tensorflow_serving/core/availability_preserving_policy.cc
+++ b/tensorflow_serving/core/availability_preserving_policy.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <unordered_set>
+
 #include "tensorflow_serving/core/availability_preserving_policy.h"
 #include "tensorflow_serving/core/loader_harness.h"
 
@@ -65,7 +67,11 @@ AvailabilityPreservingPolicy::GetNextAction(
     optional<ServableId> version_to_unload =
         GetLowestServableId(unaspired_serving_versions);
     if (version_to_unload) {
-      return {{Action::kUnload, version_to_unload.value()}};
+      std::unordered_set<int64> specific_versions =
+          GetConfiguringSpecificVersions(version_to_unload.value().name);
+      if (specific_versions.count(version_to_unload.value().version) == 0) {
+        return {{Action::kUnload, version_to_unload.value()}};
+      }
     }
   }
 

--- a/tensorflow_serving/model_servers/server_core.cc
+++ b/tensorflow_serving/model_servers/server_core.cc
@@ -349,6 +349,7 @@ Status ServerCore::AddModelsViaModelConfigList() {
 
     // Stow the source components.
     storage_path_source_and_router_ = {source.get(), router.get()};
+    manager_->SetPolicyStoragePathSource(storage_path_source_and_router_->source);
     manager_.AddDependency(std::move(source));
     if (prefix_source_adapter != nullptr) {
       manager_.AddDependency(std::move(prefix_source_adapter));

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -384,6 +384,24 @@ void FileSystemStoragePathSource::SetAspiredVersionsCallback(
   }
 }
 
+std::unordered_set<int64>
+FileSystemStoragePathSource::GetConfiguringSpecificVersions(
+    const std::string& servable_name) const {
+  mutex_lock l(mu_);
+
+  std::unordered_set<int64> specific_versions;
+  for (const FileSystemStoragePathSourceConfig::ServableToMonitor& servable :
+       config_.servables()) {
+    if (servable.servable_name() == servable_name) {
+       specific_versions.insert(
+           servable.servable_version_policy().specific().versions().begin(),
+           servable.servable_version_policy().specific().versions().end());
+       break;
+    }
+  }
+  return specific_versions;
+}
+
 Status FileSystemStoragePathSource::PollFileSystemAndInvokeCallback() {
   mutex_lock l(mu_);
   std::map<string, std::vector<ServableData<StoragePath>>>

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <utility>
+#include <unordered_set>
 
 #include "absl/types/variant.h"
 #include "tensorflow/core/kernels/batching_util/periodic_function.h"
@@ -77,6 +78,9 @@ class FileSystemStoragePathSource : public Source<StoragePath> {
     mutex_lock l(mu_);
     return config_;
   }
+
+  std::unordered_set<int64> GetConfiguringSpecificVersions(
+      const std::string& servable_name) const;
 
  private:
   friend class internal::FileSystemStoragePathSourceTestAccess;


### PR DESCRIPTION
Under specific-version policy, when the version directory is deleted by mistake or something wrong with the filesystem, the desired version in config would be unloaded, which is a disaster for online service.
So the feature of this pull request is an advice that don't unload versions in config under specific-version policy even when the version directory missed.