### PR TITLE
Refresh aspired servables/versions following config update

### DIFF
--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
@@ -90,6 +90,10 @@ class FileSystemStoragePathSource : public Source<StoragePath> {
   // such child.
   Status PollFileSystemAndInvokeCallback();
 
+  // Logs servable version information before invoking 'aspired_versions_callback_'
+  void LogVersionsAndInvokeCallback(const string& servable,
+      const std::vector<ServableData<StoragePath>>& versions);
+
   // Sends empty aspired-versions lists for each servable in 'servable_names'.
   Status UnaspireServables(const std::set<string>& servable_names)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);


### PR DESCRIPTION
Currently when the configured model list is updated via a call to `handleReloadConfigRequest`, the request thread blocks until any newly added models become available.

Their availability however depends on the filesystem polling thread rescanning the filesystem at some periodic interval, meaning that there's an arbitrary delay before the requested changes actually take effect and the RPC returns.

This problem may not be very noticeable with the default polling interval of 1 second, but seems undesirable for longer intervals and in particular makes API-based dynamic reconfiguration incompatible with the `--file_system_poll_wait_seconds=0` setting (in this case all `handleReloadConfigRequest` calls time-out and do not take effect).