### PR TITLE
Export GRPC and REST API port

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile
+++ b/tensorflow_serving/tools/docker/Dockerfile
@@ -34,12 +34,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install TF Serving pkg
 COPY --from=build_image /usr/local/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
+ENV GRPC_PORT=8500
+ENV PORT=8501
+
 # Expose ports
 # gRPC
-EXPOSE 8500
+EXPOSE $GRPC_PORT
 
 # REST
-EXPOSE 8501
+EXPOSE $PORT
 
 # Set where models should be stored in the container
 ENV MODEL_BASE_PATH=/models
@@ -51,7 +54,7 @@ ENV MODEL_NAME=model
 # Create a script that runs the model server so we can use environment variables
 # while also passing in arguments from the docker command line
 RUN echo '#!/bin/bash \n\n\
-tensorflow_model_server --port=8500 --rest_api_port=8501 \
+tensorflow_model_server --port=${GRPC_PORT} --rest_api_port=${PORT} \
 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
 "$@"' > /usr/bin/tf_serving_entrypoint.sh \
 && chmod +x /usr/bin/tf_serving_entrypoint.sh


### PR DESCRIPTION
We are adding support for Google Cloud Run. (Google Cloud Run + Anthos).
The contract for Google Cloud Anthos consists of the ENV Variable PORT. Which we are defining here as PORT. This is used to enable the service and provide a REST endpoint (HTTP). While we can generate a new container based on this image, I would like to expose this option in source container:

```
docker run -p 8502:8502 --mount type=bind,source=/Users/gogasca/Desktop/cloud_run/resnet_v2_fp32_savedmodel_NHWC_jpg/,target=/models/resnet -e PORT=8502 -e MODEL_NAME=resnet --rm -i -t tensorflow/serving
...
2020-01-27 19:20:09.157365: I tensorflow_serving/model_servers/server.cc:378] Exporting HTTP/REST API at:localhost:8502 ...
```