### PR TITLE
Fix a compile warning thrown by gcc-9

### DIFF
--- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
+++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
@@ -258,9 +258,7 @@ bool EvHTTPRequest::NeedUncompressGzipContent() {
   if (handler_options_ != nullptr &&
       handler_options_->auto_uncompress_input()) {
     auto content_encoding = GetRequestHeader(HTTPHeaders::CONTENT_ENCODING);
-    if (content_encoding != nullptr) {
-      return content_encoding.find("gzip") != absl::string_view::npos;
-    }
+    return content_encoding.find("gzip") != absl::string_view::npos;
   }
 
   return false;


### PR DESCRIPTION
The warning is 
```
evhttp_request.cc:260:29: error: null argument where non-null required (argument 2) [-Werror=nonnull]
  260 |     if (content_encoding != nullptr) {
      |                             ^~~~~~~
```
 GetRequestHeader will always return a valid string_view, there is no need to explicitly compare it to nullptr.