### PR TITLE
Add CentOS 7 Docker instructions

### DIFF
--- a/tensorflow_serving/tools/docker/centos7/Dockerfile
+++ b/tensorflow_serving/tools/docker/centos7/Dockerfile
@@ -1,0 +1,44 @@
+# This file is based on Google TensorFlow Serving Dockerfile file with
+# modifications needed to build the project for CentOS7.
+# Original file is licenced under Apache Licence, Version 2.0:
+# https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile
+ARG TF_SERVING_VERSION=latest
+ARG TF_SERVING_BUILD_IMAGE=tf-serving-centos7-devel:${TF_SERVING_VERSION}
+
+FROM ${TF_SERVING_BUILD_IMAGE} as build_image
+FROM centos:7.7.1908
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+ARG TF_SERVING_VERSION_GIT_COMMIT=head
+
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+RUN yum update -y
+
+# Install TF Serving pkg
+COPY --from=build_image /usr/local/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
+
+# Expose ports
+# gRPC
+EXPOSE 8500
+
+# REST
+EXPOSE 8501
+
+# Set where models should be stored in the container
+ENV MODEL_BASE_PATH=/models
+RUN mkdir -p ${MODEL_BASE_PATH}
+
+# The only required piece is the model name in order to differentiate endpoints
+ENV MODEL_NAME=model
+
+# Create a script that runs the model server so we can use environment variables
+# while also passing in arguments from the docker command line
+RUN echo '#!/bin/bash \n\n\
+tensorflow_model_server --port=8500 --rest_api_port=8501 \
+--model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
+"$@"' > /usr/bin/tf_serving_entrypoint.sh \
+&& chmod +x /usr/bin/tf_serving_entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/tf_serving_entrypoint.sh"]

--- a/tensorflow_serving/tools/docker/centos7/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/centos7/Dockerfile.devel
@@ -1,0 +1,110 @@
+# This file is based on Google TensorFlow Serving Dockerfile.devel file with
+# Modifications needed to build the project for CentOS 7.
+# Original file is licenced under Apache Licence, Version 2.0:
+# https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.devel
+
+FROM centos:7.7.1908 as base_build
+
+# Set locale
+ENV LANG en_US.UTF-8
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+# Picking latest working revision until official Dockerfile.devel is fixed.
+ARG TF_SERVING_VERSION_GIT_COMMIT=4de4c7b6d2f5932f8f2be939335e38c94f1f2dac
+
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+# Enable SCL CentOS 7 repo and install build packages
+RUN yum install -y centos-release-scl && yum update -y && yum install -y \
+        which \
+        devtoolset-8-gcc \
+        devtoolset-8-gcc-c++ \
+        devtoolset-8-make \
+        patch \
+        automake \
+        ca-certificates \
+        curl \
+        git \
+        libtool \
+        mlocate \
+        java-1.8.0-openjdk-devel \
+        swig \
+        unzip \
+        wget \
+        zip
+
+# Note: This is for python2 which soon to be unsupported
+RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm -f get-pip.py
+
+RUN pip --no-cache-dir install \
+    future>=0.17.1 \
+    grpcio \
+    h5py \
+    keras_applications>=1.0.8 \
+    keras_preprocessing>=1.1.0 \
+    mock \
+    numpy \
+    requests \
+    --ignore-installed setuptools \
+    --ignore-installed six
+
+# Set up Bazel
+ENV BAZEL_VERSION 0.24.1
+WORKDIR /
+RUN mkdir /bazel && \
+    cd /bazel && \
+    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
+    chmod +x bazel-*.sh && \
+    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+    cd / && \
+    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+# Download TF Serving sources (optionally at specific commit).
+WORKDIR /tensorflow-serving
+RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving . && \
+    git remote add upstream https://github.com/tensorflow/serving.git && \
+    if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
+
+
+FROM base_build as binary_build
+# Build, and install TensorFlow Serving
+# Example: '--local_ram_resources=HOST_RAM*.5, --local_cpu_resources=HOST_CPUS-1'
+ARG TF_SERVING_BUILD_OPTIONS="--config=nativeopt --local_ram_resources=HOST_RAM*.5 --discard_analysis_cache --nokeep_state_after_build --notrack_incremental_state"
+RUN echo "Building with build options: ${TF_SERVING_BUILD_OPTIONS}"
+ARG TF_SERVING_BAZEL_OPTIONS=""
+RUN echo "Building with Bazel options: ${TF_SERVING_BAZEL_OPTIONS}"
+
+# CentOS 7: Here and in the next RUN added command to enable devtoolset-8 env.
+RUN source /opt/rh/devtoolset-8/enable && \
+    bazel build --color=yes --curses=yes \
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/model_servers:tensorflow_model_server && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server \
+    /usr/local/bin/
+
+# Build and install TensorFlow Serving API
+RUN source /opt/rh/devtoolset-8/enable && \
+    bazel build --color=yes --curses=yes \
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
+    /tmp/pip && \
+    pip --no-cache-dir install --upgrade \
+    /tmp/pip/tensorflow_serving_api-*.whl && \
+    rm -rf /tmp/pip
+
+FROM binary_build as clean_build
+# Clean up Bazel cache when done.
+RUN bazel clean --expunge --color=yes && \
+    rm -rf /root/.cache
+CMD ["/bin/bash"]

--- a/tensorflow_serving/tools/docker/centos7/README.md
+++ b/tensorflow_serving/tools/docker/centos7/README.md
@@ -1,0 +1,3 @@
+Files for using the [Docker](http://www.docker.com) container system.
+Please see [Docker instructions](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/docker.md)
+for more info.


### PR DESCRIPTION
Fixes #1542 

This is a starter kit to add support for building CentOS 7 based Docker images that'd be maintained in parallel to the Ubuntu based ones. There are some opportunities for refactoring or consolidation that can also be tackled that's not handled in the first version of this change (could possibly be done through follow up PRs).

*Notes:*
* Using the current instructions, CentOS 7 is diverged from master starting at 1a36026, i.e. this is using 4de4c7b to successfully build.
* The main difference between these CentOS 7 instructions and Ubuntu is Bazel `1.2.1` and Python `3.x`.
* I may have narrowed down the problem to the version of `gcc` used for `libtool` out of the box:
    ```
    ---> Package libtool.x86_64 0:2.4.2-22.el7_3 will be installed
    --> Processing Dependency: gcc = 4.8.5 for package: libtool-2.4.2-22.el7_3.x86_64
    ```

A couple of errors that I wasn't able to fully resolve on `master`, hence the "starter kit" label:
```
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
WARNING: Download from https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/2a2c812ab2330c9aac33335f10679a346436acfb.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
DEBUG: Rule 'io_bazel_rules_docker' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1556410077 -0400"
DEBUG: Call stack for the definition of repository 'io_bazel_rules_docker' which is a git_repository (rule definition at /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/bazel_tools/tools/build_defs/repo/git.bzl:195:18):
 - /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/bazel_toolchains/repositories/repositories.bzl:37:9
 - /tensorflow-serving/WORKSPACE:39:1
WARNING: Download from http://mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/36d37ab992038f52276ca66b9da80c1cf0f57dc2.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
WARNING: Download from https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/66be6c76fc01.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
INFO: Analyzed target //tensorflow_serving/model_servers:tensorflow_model_server (208 packages loaded, 15593 targets configured).
INFO: Found 1 target...
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/com_google_protobuf/BUILD:406:1: Linking of rule '@com_google_protobuf//:protoc' failed (Exit 1)
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/code_generator.o:code_generator.cc:function google::protobuf::compiler::ParseGeneratorParameter(std::string const&, std::vector<std::pair<std::string, std::string>, std::allocator<std::pair<std::string, std::string> > >*): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function google::protobuf::io::StringOutputStream::~StringOutputStream(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function google::protobuf::internal::ArenaStringPtr::CreateInstanceNoArena(std::string const*) [clone .isra.22] [clone .cold.459]: error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function non-virtual thunk to google::protobuf::compiler::CommandLineInterface::ErrorPrinter::~ErrorPrinter(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function non-virtual thunk to google::protobuf::compiler::CommandLineInterface::ErrorPrinter::~ErrorPrinter(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function google::protobuf::compiler::(anonymous namespace)::PluginName(std::string const&, std::string const&): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function google::protobuf::compiler::CommandLineInterface::InterpretArgument(std::string const&, std::string const&): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/command_line_interface.o:command_line_interface.cc:function google::protobuf::compiler::CommandLineInterface::MemoryOutputStream::~MemoryOutputStream(): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/java_helpers.o:java_helpers.cc:function google::protobuf::compiler::java::SortFieldsByNumber(google::protobuf::Descriptor const*) [clone .cold.236]: error: undefined reference to '__cxa_throw_bad_array_new_length'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/objectivec_message.o:objectivec_message.cc:function google::protobuf::compiler::objectivec::(anonymous namespace)::SortFieldsByNumber(google::protobuf::Descriptor const*) [clone .cold.289]: error: undefined reference to '__cxa_throw_bad_array_new_length'
bazel-out/host/bin/external/com_google_protobuf/_objs/protoc_lib/objectivec_message.o:objectivec_message.cc:function google::protobuf::compiler::objectivec::MessageGenerator::GenerateSource(google::protobuf::io::Printer*) [clone .cold.292]: error: undefined reference to '__cxa_throw_bad_array_new_length'
bazel-out/host/bin/external/com_google_protobuf/_objs/protobuf/dynamic_message.o:dynamic_message.cc:function google::protobuf::DynamicMessageFactory::GetPrototypeNoLock(google::protobuf::Descriptor const*) [clone .cold.103]: error: undefined reference to '__cxa_throw_bad_array_new_length'
bazel-out/host/bin/external/com_google_protobuf/_objs/protobuf_lite/extension_set.o:extension_set.cc:function google::protobuf::internal::ExtensionSet::~ExtensionSet(): error: undefined reference to 'operator delete[](void*, unsigned long)'
bazel-out/host/bin/external/com_google_protobuf/_objs/protobuf_lite/extension_set.o:extension_set.cc:function google::protobuf::internal::ExtensionSet::GrowCapacity(unsigned long): error: undefined reference to 'operator delete[](void*, unsigned long)'
collect2: error: ld returned 1 exit status
Target //tensorflow_serving/model_servers:tensorflow_model_server failed to build
INFO: Elapsed time: 1379.471s, Critical Path: 46.90s
INFO: 1571 processes: 1571 local.
FAILED: Build did NOT complete successfully
```
I've also arrived at #1563 using the `Development Tools` group or a subset of that, e.g.:
```
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/grpc/BUILD:439:1: Linking of rule '@grpc//:grpc_cpp_plugin' failed (Exit 1)
```

A couple of follow ups:
1. CI/checks to build and publish an image for CentOS 7.
1. Figure out which of the GCC libs is causing the compatibility issue with Bazel `1.2.1`, e.g. `devtoolset-9`, `gcc-4.9.x`, etc.