### PR TITLE
Loosen model interface checks

### DIFF
--- a/tensorflow_serving/servables/tensorflow/predict_util.cc
+++ b/tensorflow_serving/servables/tensorflow/predict_util.cc
@@ -64,7 +64,25 @@ std::set<string> SetDifference(std::set<string> set_a, std::set<string> set_b) {
 
 Status VerifyRequestInputsSize(const SignatureDef& signature,
                                const PredictRequest& request) {
-  if (request.inputs().size() != signature.inputs().size()) {
+  if (request.inputs().size() >= signature.inputs().size()) {
+    const std::set<string> request_inputs = GetMapKeys(request.inputs());
+    const std::set<string> signature_inputs = GetMapKeys(signature.inputs());
+    const std::set<string> missing =
+      SetDifference(signature_inputs, request_inputs);
+    if (!missing.empty()) {
+      const std::set<string> sent_extra =
+        SetDifference(request_inputs, signature_inputs);
+      return tensorflow::Status(
+        tensorflow::error::INVALID_ARGUMENT,
+	absl::StrCat(
+	  "input size does not match signature: ", request.inputs().size(),
+	  "!=", signature.inputs().size(), " len({",
+	  absl::StrJoin(request_inputs, ","), "}) != len({",
+	  absl::StrJoin(signature_inputs, ","), "}). Sent extra: {",
+	  absl::StrJoin(sent_extra, ","), "}. Missing but required: {",
+	  absl::StrJoin(missing, ","), "}."));
+    }
+  } else {
     const std::set<string> request_inputs = GetMapKeys(request.inputs());
     const std::set<string> signature_inputs = GetMapKeys(signature.inputs());
     const std::set<string> sent_extra =
@@ -93,10 +111,10 @@ Status PreProcessPrediction(const SignatureDef& signature,
                             std::vector<string>* output_tensor_aliases) {
   TF_RETURN_IF_ERROR(VerifySignature(signature));
   TF_RETURN_IF_ERROR(VerifyRequestInputsSize(signature, request));
-  for (auto& input : request.inputs()) {
+  for (auto& input : signature.inputs()) {
     const string& alias = input.first;
-    auto iter = signature.inputs().find(alias);
-    if (iter == signature.inputs().end()) {
+    auto iter = request.inputs().find(alias);
+    if (iter == request.inputs().end()) {
       return tensorflow::Status(
           tensorflow::error::INVALID_ARGUMENT,
           strings::StrCat("input tensor alias not found in signature: ", alias,
@@ -105,11 +123,11 @@ Status PreProcessPrediction(const SignatureDef& signature,
                           "}."));
     }
     Tensor tensor;
-    if (!tensor.FromProto(input.second)) {
+    if (!tensor.FromProto(iter->second)) {
       return tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
                                 "tensor parsing error: " + alias);
     }
-    inputs->emplace_back(std::make_pair(iter->second.name(), tensor));
+    inputs->emplace_back(std::make_pair(input.second.name(), tensor));
   }
 
   // Prepare run target.


### PR DESCRIPTION
Hello.

This patch loosens the checking of the Predict API's model interface.
If the key of "request.inputs()" satisfies the required key of "signature.inputs()", the request is predictable.
This allows you to add features to a running client server at any given time, even though they are not used for prediction.
The advantage of this patch is that the API of the model is backwards compatible when AB testing a model with added features on a running service.

Let me know what you think.