### PR TITLE
Supports serialized POST body messages in protocol buffer format

### DIFF
--- a/tensorflow_serving/model_servers/http_rest_api_handler.h
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.h
@@ -45,6 +45,7 @@ class ModelSpec;
 //
 //   POST /v1/models/<model_name>:(classify|regress|predict)
 //   POST /v1/models/<model_name>/versions/<ver>:(classify|regress|predict)
+//   POST /v1/models/protobuf/versions/<ver>:(classify|regress|predict)
 //
 // o Model status
 //
@@ -97,6 +98,12 @@ class HttpRestApiHandler {
                                const absl::optional<int64>& model_version,
                                const absl::string_view request_body,
                                string* output);
+  Status ProcessProtobufClassifyRequest(const absl::string_view request_body,
+				       string* output);
+  Status ProcessProtobufRegressRequest(const absl::string_view request_body,
+				       string* output);
+  Status ProcessProtobufPredictRequest(const absl::string_view request_body,
+				       string* output);
   Status ProcessModelStatusRequest(const absl::string_view model_name,
                                    const absl::string_view model_version_str,
                                    string* output);


### PR DESCRIPTION
Hello.

This patch supports serialized POST body messages in protocol buffer format in the RESTful API.

Raw json message in the RESTful API is too much traffic for applications that handle a lot of requests.
Fortunately, gzip format is already supported, but you can expect further compression by serializing in protocol buffer format.

API Specification:
If "protobuf" is specified for "model_name" in the current API specification, body messages in protocol buffer format will be interpreted and predicted.
In this case, "model_name" must be specified by ModelSpec.name.