### PR TITLE
Return error strings that conform to JSON specs, to prevent malformed JSON responses that fail to parse.

### DIFF
--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -67,14 +67,6 @@ void AddHeaders(std::vector<std::pair<string, string>>* headers) {
   headers->push_back({"Content-Type", "application/json"});
 }
 
-void FillJsonErrorMsg(const string& errmsg, string* output) {
-  // Errors are represented as following JSON object:
-  // {
-  //   "error": "<CEscaped error message string>"
-  // }
-  absl::StrAppend(output, R"({ "error": ")", absl::CEscape(errmsg), R"(" })");
-}
-
 }  // namespace
 
 Status HttpRestApiHandler::ProcessRequest(
@@ -124,9 +116,7 @@ Status HttpRestApiHandler::ProcessRequest(
     }
   }
 
-  if (!status.ok()) {
-    FillJsonErrorMsg(status.error_message(), output);
-  }
+  MakeJsonFromStatus(status, output);
   return status;
 }
 

--- a/tensorflow_serving/model_servers/http_rest_api_handler_test.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler_test.cc
@@ -267,6 +267,13 @@ TEST_F(HttpRestApiHandlerTest, PredictRequestErrors) {
       "POST", req_path, R"({ "instances": ["x", "y"] })", &headers, &output);
   EXPECT_TRUE(errors::IsInvalidArgument(status));
   EXPECT_THAT(status.error_message(), HasSubstr("not of expected type: float"));
+
+  // Incorrect signature_name type.
+  status = handler_.ProcessRequest(
+      "POST", req_path, R"({ "signature_name": 100 })", &headers, &output);
+  EXPECT_TRUE(errors::IsInvalidArgument(status));
+  EXPECT_THAT(GetJsonErrorMsg(output),
+              HasSubstr("'signature_name' key must be a string value."));
 }
 
 TEST_F(HttpRestApiHandlerTest, Predict) {

--- a/tensorflow_serving/util/json_tensor.cc
+++ b/tensorflow_serving/util/json_tensor.cc
@@ -74,6 +74,9 @@ constexpr char kPredictResponseOutputsKey[] = "outputs";
 // in the JSON response object.
 constexpr char kClassifyRegressResponseKey[] = "results";
 
+// All error messages are keyed off this in the JSON response object.
+constexpr char kErrorResponseKey[] = "error";
+
 // All binary (base64 encoded) strings are keyd off this in JSON.
 constexpr char kBase64Key[] = "b64";
 
@@ -1117,6 +1120,18 @@ Status MakeJsonFromRegressionResult(const RegressionResult& result,
   writer.EndObject();
   json->assign(buffer.GetString());
   return Status::OK();
+}
+
+void MakeJsonFromStatus(const tensorflow::Status& status, string* json) {
+  if (status.ok()) return;
+  const string& error_message = status.error_message();
+  rapidjson::StringBuffer buffer;
+  rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+  writer.StartObject();
+  writer.Key(kErrorResponseKey);
+  writer.String(error_message.c_str(), error_message.size());
+  writer.EndObject();
+  json->append(buffer.GetString());
 }
 
 }  // namespace serving

--- a/tensorflow_serving/util/json_tensor.h
+++ b/tensorflow_serving/util/json_tensor.h
@@ -297,6 +297,17 @@ tensorflow::Status MakeJsonFromClassificationResult(
 tensorflow::Status MakeJsonFromRegressionResult(const RegressionResult& result,
                                                 string* json);
 
+// Make JSON object from Status.
+//
+// The output JSON object is formatted as follows:
+//
+// {
+//   "error": "<status error message>"
+// }
+//
+// If `status` is OK then we do not append anything to output `json`.
+void MakeJsonFromStatus(const tensorflow::Status& status, string* json);
+
 }  // namespace serving
 }  // namespace tensorflow
 

--- a/tensorflow_serving/util/json_tensor_test.cc
+++ b/tensorflow_serving/util/json_tensor_test.cc
@@ -1399,6 +1399,22 @@ TEST(ClassifyRegressnResultTest, JsonFromResultErrors) {
   EXPECT_THAT(status.error_message(), HasSubstr("empty RegressionResults"));
 }
 
+TEST(MakeJsonFromTensors, StatusOK) {
+  string json;
+  MakeJsonFromStatus(Status::OK(), &json);
+  EXPECT_EQ(json, "");
+}
+
+TEST(MakeJsonFromTensors, StatusError) {
+  string json;
+  MakeJsonFromStatus(errors::InvalidArgument("Bad key: \"key\""), &json);
+  TF_EXPECT_OK(CompareJson(json, R"({ "error": "Bad key: \"key\"" })"));
+
+  json.clear();
+  MakeJsonFromStatus(errors::InvalidArgument("Bad key: 'key'"), &json);
+  TF_EXPECT_OK(CompareJson(json, R"({ "error": "Bad key: 'key'" })"));
+}
+
 }  // namespace
 }  // namespace serving
 }  // namespace tensorflow


### PR DESCRIPTION
Fixes #1600

PiperOrigin-RevId: 310921928
(cherry picked from commit e1ceccbde64272fbe09915cc34053ad44648447e)