### PR TITLE
Change the checksum of unicode-org/icu tar file and resolved #1633

### DIFF
--- a/tensorflow_serving/workspace.bzl
+++ b/tensorflow_serving/workspace.bzl
@@ -49,7 +49,7 @@ def tf_serving_workspace():
     http_archive(
         name = "icu",
         strip_prefix = "icu-release-64-2",
-        sha256 = "dfc62618aa4bd3ca14a3df548cd65fe393155edd213e49c39f3a30ccd618fc27",
+        sha256 = "10cd92f1585c537d937ecbb587f6c3b36a5275c87feabe05d777a828677ec32f",
         urls = [
             "https://github.com/unicode-org/icu/archive/release-64-2.zip",
         ],


### PR DESCRIPTION
The actual checksum of `release-64-2.zip` is `10cd92f1585c537d937ecbb587f6c3b36a5275c87feabe05d777a828677ec32f` instead of `dfc62618aa4bd3ca14a3df548cd65fe393155edd213e49c39f3a30ccd618fc27`.

We can verify by manually downloading and computing with following commands.

```
wget https://github.com/unicode-org/icu/archive/release-64-2.zip

shasum -a 256 ./release-64-2.zip
```