### PR TITLE
Add Python 3.7 as supported for tensorflow-serving-api package.

### DIFF
--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -81,6 +81,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',


### PR DESCRIPTION
The API package itself is a collection of .proto files, and should be
compatible with Python 3.7. Underlying dependencies: protobuf and grpcio
both support Python 3.7, so we can too.

Fixes #1640

PiperOrigin-RevId: 313979135
(cherry picked from commit 3a0bdbe5c216e4eeab8110cad8d959d21a2e376a)