### PR TITLE
Install cuda-nvrtc 10.1 into release tf serving gpu docker image.

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.gpu
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-command-line-tools-10-1 \
         libcublas10=10.2.1.243-1 \
         libcublas-dev=10.2.1.243-1 \
+        cuda-nvrtc-10-1 \
         cuda-cufft-10-1 \
         cuda-curand-10-1 \
         cuda-cusolver-10-1 \


### PR DESCRIPTION
PiperOrigin-RevId: 314861537
(cherry picked from commit 74ea413db4407c1affe2b9fa69dc53ecdba61fa6)