### PR TITLE
Added model_platform to the model_config_list documentation

### DIFF
--- a/tensorflow_serving/g3doc/serving_config.md
+++ b/tensorflow_serving/g3doc/serving_config.md
@@ -76,10 +76,12 @@ model_config_list {
   config {
     name: 'my_first_model'
     base_path: '/tmp/my_first_model/'
+    model_platform: 'tensorflow'
   }
   config {
     name: 'my_second_model'
     base_path: '/tmp/my_second_model/'
+    model_platform: 'tensorflow'
   }
 }
 ```


### PR DESCRIPTION
It seems the TF Serving docs for `model_config_list` is missing the required argument `model_platform`. If not present, the server will fail with this error below:

```
Error: Invalid argument: Illegal setting neither ModelServerConfig::model_type (deprecated) nor ModelServerConfig::model_platform.
```

Could the two additional lines be added to the example configuration file for the `model_config_list`?