### PR TITLE
Add more exported metrics for prediction

### DIFF
--- a/tensorflow_serving/servables/tensorflow/util.h
+++ b/tensorflow_serving/servables/tensorflow/util.h
@@ -114,6 +114,14 @@ Status EstimateResourceFromPathUsingDiskState(const string& path,
 void RecordRuntimeLatency(const string& model_name, const string& api,
                           const string& runtime, int64 latency_usec);
 
+// Update counters for successful predictions.
+void UpdateSuccessfulPredictionCounters(const string& model_name, const string& api, 
+                              const string& runtime);
+
+// Update counters for failed predictions.
+void UpdateFailedPredictionCounters(const string& model_name, const string& api, 
+                              const string& runtime);
+
 }  // namespace serving
 }  // namespace tensorflow
 


### PR DESCRIPTION
I'm adding:
- Counters for successful and failed predictions (per-model and for all, aggregated by api/runtime)
- Total inference time (aggregated by api/runtime)