### PR TITLE
option to disable grpc over http

### DIFF
--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -182,8 +182,8 @@ void Server::PollFilesystemAndReloadConfig(const string& config_file_path) {
 }
 
 Status Server::BuildAndStart(const Options& server_options) {
-  if (server_options.grpc_port == 0) {
-    return errors::InvalidArgument("server_options.grpc_port is not set.");
+  if (server_options.grpc_port <= 0 && server_options.grpc_socket_path.empty()) {
+    return errors::InvalidArgument("one of server_options.grpc_port/server_options.grpc_socket_path should be set.");
   }
 
   if (server_options.model_base_path.empty() &&
@@ -340,9 +340,12 @@ Status Server::BuildAndStart(const Options& server_options) {
   profiler_service_ = tensorflow::profiler::CreateProfilerService();
 
   ::grpc::ServerBuilder builder;
-  builder.AddListeningPort(
-      server_address,
-      BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  // If defined, listen to a http port for gRPC.
+  if (server_options.grpc_port > 0) {
+      builder.AddListeningPort(
+              server_address,
+              BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  }
   // If defined, listen to a UNIX socket for gRPC.
   if (!server_options.grpc_socket_path.empty()) {
     const string grpc_socket_uri = "unix:" + server_options.grpc_socket_path;
@@ -375,7 +378,9 @@ Status Server::BuildAndStart(const Options& server_options) {
   if (grpc_server_ == nullptr) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
-  LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
+  if(server_options.grpc_port > 0) {
+    LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
+  }
   if (!server_options.grpc_socket_path.empty()) {
     LOG(INFO) << "Running gRPC ModelServer at UNIX socket "
               << server_options.grpc_socket_path << " ...";


### PR DESCRIPTION
Option to disable TF serving on grpc over http when TF serving starts on unix domain socket. 

The issue is described in more detail here
https://github.com/tensorflow/serving/issues/1764