### PR TITLE
setting flag --grpc_port=0 disables gRPC over TCP port (Fixes #1764) 

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -58,7 +58,8 @@ int main(int argc, char** argv) {
   bool display_version = false;
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("port", &options.grpc_port,
-                       "Port to listen on for gRPC API"),
+                       "TCP port to listen on for gRPC/HTTP API. Disabled if "
+                       "port set to zero."),
       tensorflow::Flag("grpc_socket_path", &options.grpc_socket_path,
                        "If non-empty, listen to a UNIX socket for gRPC API "
                        "on the given path. Can be either relative or absolute "

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -184,7 +184,8 @@ void Server::PollFilesystemAndReloadConfig(const string& config_file_path) {
 Status Server::BuildAndStart(const Options& server_options) {
   if (server_options.grpc_port == 0 && server_options.grpc_socket_path.empty()) {
       return errors::InvalidArgument(
-              "At least one of server_options.grpc_port or server_options.grpc_socket_path must be set.");
+              "At least one of server_options.grpc_port or "
+              "server_options.grpc_socket_path must be set.");
   }
 
   if (server_options.model_base_path.empty() &&

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -182,8 +182,8 @@ void Server::PollFilesystemAndReloadConfig(const string& config_file_path) {
 }
 
 Status Server::BuildAndStart(const Options& server_options) {
-  if (server_options.grpc_port == 0) {
-    return errors::InvalidArgument("server_options.grpc_port is not set.");
+  if (server_options.grpc_port <= 0 && server_options.grpc_socket_path.empty()) {
+    return errors::InvalidArgument("one of server_options.grpc_port/server_options.grpc_socket_path should be set.");
   }
 
   if (server_options.model_base_path.empty() &&
@@ -340,9 +340,12 @@ Status Server::BuildAndStart(const Options& server_options) {
   profiler_service_ = tensorflow::profiler::CreateProfilerService();
 
   ::grpc::ServerBuilder builder;
-  builder.AddListeningPort(
-      server_address,
-      BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  // If defined, listen to a http port for gRPC.
+  if (server_options.grpc_port > 0) {
+      builder.AddListeningPort(
+              server_address,
+              BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+  }
   // If defined, listen to a UNIX socket for gRPC.
   if (!server_options.grpc_socket_path.empty()) {
     const string grpc_socket_uri = "unix:" + server_options.grpc_socket_path;
@@ -375,7 +378,9 @@ Status Server::BuildAndStart(const Options& server_options) {
   if (grpc_server_ == nullptr) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
-  LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
+  if(server_options.grpc_port > 0) {
+    LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
+  }
   if (!server_options.grpc_socket_path.empty()) {
     LOG(INFO) << "Running gRPC ModelServer at UNIX socket "
               << server_options.grpc_socket_path << " ...";

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -182,8 +182,9 @@ void Server::PollFilesystemAndReloadConfig(const string& config_file_path) {
 }
 
 Status Server::BuildAndStart(const Options& server_options) {
-  if (server_options.grpc_port <= 0 && server_options.grpc_socket_path.empty()) {
-    return errors::InvalidArgument("one of server_options.grpc_port/server_options.grpc_socket_path should be set.");
+  if (server_options.grpc_port == 0 && server_options.grpc_socket_path.empty()) {
+      return errors::InvalidArgument(
+              "At least one of server_options.grpc_port or server_options.grpc_socket_path must be set.");
   }
 
   if (server_options.model_base_path.empty() &&
@@ -342,9 +343,9 @@ Status Server::BuildAndStart(const Options& server_options) {
   ::grpc::ServerBuilder builder;
   // If defined, listen to a http port for gRPC.
   if (server_options.grpc_port > 0) {
-      builder.AddListeningPort(
-              server_address,
-              BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+    builder.AddListeningPort(
+          server_address,
+          BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
   }
   // If defined, listen to a UNIX socket for gRPC.
   if (!server_options.grpc_socket_path.empty()) {
@@ -378,7 +379,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   if (grpc_server_ == nullptr) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
-  if(server_options.grpc_port > 0) {
+  if (server_options.grpc_port > 0) {
     LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
   }
   if (!server_options.grpc_socket_path.empty()) {

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -342,7 +342,7 @@ Status Server::BuildAndStart(const Options& server_options) {
 
   ::grpc::ServerBuilder builder;
   // If defined, listen to a http port for gRPC.
-  if (server_options.grpc_port > 0) {
+  if (server_options.grpc_port != 0) {
     builder.AddListeningPort(
           server_address,
           BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
@@ -379,7 +379,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   if (grpc_server_ == nullptr) {
     return errors::InvalidArgument("Failed to BuildAndStart gRPC server");
   }
-  if (server_options.grpc_port > 0) {
+  if (server_options.grpc_port != 0) {
     LOG(INFO) << "Running gRPC ModelServer at " << server_address << " ...";
   }
   if (!server_options.grpc_socket_path.empty()) {

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -182,10 +182,11 @@ void Server::PollFilesystemAndReloadConfig(const string& config_file_path) {
 }
 
 Status Server::BuildAndStart(const Options& server_options) {
-  if (server_options.grpc_port == 0 && server_options.grpc_socket_path.empty()) {
-      return errors::InvalidArgument(
-              "At least one of server_options.grpc_port or "
-              "server_options.grpc_socket_path must be set.");
+  if (server_options.grpc_port == 0 &&
+      server_options.grpc_socket_path.empty()) {
+    return errors::InvalidArgument(
+      "At least one of server_options.grpc_port or "
+      "server_options.grpc_socket_path must be set.");
   }
 
   if (server_options.model_base_path.empty() &&
@@ -342,11 +343,11 @@ Status Server::BuildAndStart(const Options& server_options) {
   profiler_service_ = tensorflow::profiler::CreateProfilerService();
 
   ::grpc::ServerBuilder builder;
-  // If defined, listen to a http port for gRPC.
+  // If defined, listen to a tcp port for gRPC/HTTP.
   if (server_options.grpc_port != 0) {
-    builder.AddListeningPort(
-          server_address,
-          BuildServerCredentialsFromSSLConfigFile(server_options.ssl_config_file));
+    builder.AddListeningPort(server_address,
+                             BuildServerCredentialsFromSSLConfigFile(
+                               server_options.ssl_config_file));
   }
   // If defined, listen to a UNIX socket for gRPC.
   if (!server_options.grpc_socket_path.empty()) {


### PR DESCRIPTION
Option to disable TF serving on grpc over http when TF serving starts on unix domain socket. 

Current Problem statement
Describe the problem the feature is intended to solve
There isn't a way to just run TF serving on unix domain socket only, as by default TF serving is started with grpc over http on port 8500.

In multi-user system TF serving running over network have disadvantage. Programs on the same host are able to connect to TF serving. Below are some challenges to secure TF server and clients:

Authorization : To restrict other programs access to TF serving APIs, authorization business logic is required by TF serving.

TLS connection : Since same network namespace is used, client connection to TF serving needs to be encrypted so that other user application can't listen.

An amazing and simple way to get away with above 2 problems is to start TF serving with GRPC over unix domain socket. Since unix domain socket use files as namespace, both of above problems are resolved.

tensorflow_model_server --grpc_socket_path=grpc_unix_domain_socket --model_config_file=models.config

The problem is that, when TF serving is started with above config, in addition to server registering with unix domain socket, TF serving also starts listening to port 8500 (grpc)
code
Running gRPC ModelServer at 0.0.0.0:8500 ... Running gRPC ModelServer at UNIX socket grpc_unix_domain_socket

Although programs would use unix domain socket for communication, but since there is an additional http application (grpc overr http) accessible by other programs , authorization is required to protect TF serving APIs
So we need a way to disable TF serving on grpc over http.

Resolution:
To start TF serving only on unix domain socket
tensorflow_model_server grpc_port=0 --grpc_socket_path=grpc_unix_domain_socket --model_config_file=models.config

