### PR TITLE
Add reconfig poll patch

### DIFF
--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -293,9 +293,9 @@ Status PollFileSystemForConfig(
 
 // Determines if, for any servables in 'config', the file system doesn't
 // currently contain at least one version under its base path.
-Status FailIfZeroVersions(const FileSystemStoragePathSourceConfig& config) {
-  std::map<string, std::vector<ServableData<StoragePath>>>
-      versions_by_servable_name;
+Status FailIfZeroVersions(const FileSystemStoragePathSourceConfig& config,
+  std::map<string, std::vector<ServableData<StoragePath>>>&
+      versions_by_servable_name) {
   TF_RETURN_IF_ERROR(
       PollFileSystemForConfig(config, &versions_by_servable_name));
   for (const auto& entry : versions_by_servable_name) {
@@ -333,15 +333,36 @@ Status FileSystemStoragePathSource::UpdateConfig(
   const FileSystemStoragePathSourceConfig normalized_config =
       NormalizeConfig(config);
 
-  if (normalized_config.fail_if_zero_versions_at_startup() ||  // NOLINT
-      normalized_config.servable_versions_always_present()) {
-    TF_RETURN_IF_ERROR(FailIfZeroVersions(normalized_config));
+  bool requireVersionPresent =
+      normalized_config.fail_if_zero_versions_at_startup() ||  // NOLINT
+      normalized_config.servable_versions_always_present();
+
+  // Only poll filesystem here if necessary
+  // Only poll filesystem here if necessary
+  if (requireVersionPresent || aspired_versions_callback_) {
+    std::map<string, std::vector<ServableData<StoragePath>>>
+        versions_by_servable_name;
+    TF_RETURN_IF_ERROR(PollFileSystemForConfig(normalized_config,
+        &versions_by_servable_name));
+
+    if (requireVersionPresent) {
+      TF_RETURN_IF_ERROR(FailIfZeroVersions(normalized_config,
+          versions_by_servable_name));
+    }
+
+    if (aspired_versions_callback_) {
+      TF_RETURN_IF_ERROR(
+          UnaspireServables(GetDeletedServables(config_, normalized_config)));
+      // Always invoke callback after updating config - an RPC thread might be
+      // waiting for the corresponding events. This is especially important
+      // if config.file_system_poll_wait_seconds() == 0.
+      for (const auto& entry : versions_by_servable_name) {
+        LogVersions(entry.second);
+        CallAspiredVersionsCallback(entry.first, entry.second);
+      }
+    }
   }
 
-  if (aspired_versions_callback_) {
-    TF_RETURN_IF_ERROR(
-        UnaspireServables(GetDeletedServables(config_, normalized_config)));
-  }
   config_ = normalized_config;
 
   return Status::OK();
@@ -401,17 +422,22 @@ Status FileSystemStoragePathSource::PollFileSystemAndInvokeCallback() {
                  << servable;
       continue;
     }
-    for (const ServableData<StoragePath>& version : versions) {
-      if (version.status().ok()) {
-        VLOG(1) << "File-system polling update: Servable:" << version.id()
-                << "; Servable path: " << version.DataOrDie()
-                << "; Polling frequency: "
-                << config_.file_system_poll_wait_seconds();
-      }
-    }
+    LogVersions(versions);
     CallAspiredVersionsCallback(servable, versions);
   }
   return Status::OK();
+}
+
+void FileSystemStoragePathSource::LogVersions(
+    const std::vector<ServableData<StoragePath>>& versions) {
+  for (const ServableData<StoragePath> &version : versions) {
+    if (version.status().ok()) {
+      VLOG(1) << "File-system polling update: Servable:" << version.id()
+              << "; Servable path: " << version.DataOrDie()
+              << "; Polling frequency: "
+              << config_.file_system_poll_wait_seconds();
+    }
+  }
 }
 
 Status FileSystemStoragePathSource::UnaspireServables(

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -338,7 +338,6 @@ Status FileSystemStoragePathSource::UpdateConfig(
       normalized_config.servable_versions_always_present();
 
   // Only poll filesystem here if necessary
-  // Only poll filesystem here if necessary
   if (requireVersionPresent || aspired_versions_callback_) {
     std::map<string, std::vector<ServableData<StoragePath>>>
         versions_by_servable_name;

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.h
@@ -90,6 +90,9 @@ class FileSystemStoragePathSource : public Source<StoragePath> {
   // such child.
   Status PollFileSystemAndInvokeCallback();
 
+  // Logs servable version information
+  void LogVersions(const std::vector<ServableData<StoragePath>>& versions);
+
   // Sends empty aspired-versions lists for each servable in 'servable_names'.
   Status UnaspireServables(const std::set<string>& servable_names)
       TF_EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
@@ -491,7 +491,7 @@ TEST(FileSystemStoragePathSourceTest, ChangeSetOfServables) {
             Eq(strings::StrCat("servable_", i)),
             ElementsAre(ServableData<StoragePath>(
                 {strings::StrCat("servable_", i), 0},
-                io::JoinPath(strings::StrCat(base_path_prefix, i), "0")))));
+                io::JoinPath(strings::StrCat(base_path_prefix, i), "0"))))).Times(2);;
   }
   TF_ASSERT_OK(source->UpdateConfig(config));
   TF_ASSERT_OK(internal::FileSystemStoragePathSourceTestAccess(source.get())
@@ -566,7 +566,7 @@ TEST(FileSystemStoragePathSourceTest, ChangeVersionPolicy) {
               ServableData<StoragePath>({"test_servable_name", 2},
                                         io::JoinPath(base_path_prefix, "2")),
               ServableData<StoragePath>({"test_servable_name", 5},
-                                        io::JoinPath(base_path_prefix, "5")))));
+                                        io::JoinPath(base_path_prefix, "5"))))).Times(2);
 
   TF_ASSERT_OK(source->UpdateConfig(config));
   TF_ASSERT_OK(internal::FileSystemStoragePathSourceTestAccess(source.get())
@@ -688,7 +688,7 @@ TEST(FileSystemStoragePathSourceTest, ServableVersionDirRenamed) {
               ServableData<StoragePath>({"test_servable_name", 1},
                                         io::JoinPath(base_path_prefix, "1")),
               ServableData<StoragePath>({"test_servable_name", 3},
-                                        io::JoinPath(base_path_prefix, "3")))));
+                                        io::JoinPath(base_path_prefix, "3"))))).Times(2);
 
   TF_ASSERT_OK(source->UpdateConfig(config));
   TF_ASSERT_OK(internal::FileSystemStoragePathSourceTestAccess(source.get())


### PR DESCRIPTION
This patch is essentially porting the patch submitted by @njhill  in PR #1518 to `2.4.0` version

Currently when the configured model list is updated via a call to handleReloadConfigRequest, the request thread blocks until any newly added models become available.

Their availability however depends on the filesystem polling thread rescanning the filesystem at some periodic interval, meaning that there's an arbitrary delay before the requested changes actually take effect and the RPC returns.

This problem may not be very noticeable with the default polling interval of 1 second, but seems undesirable for longer intervals and in particular makes API-based dynamic reconfiguration incompatible with the --file_system_poll_wait_seconds=0 setting (in this case all handleReloadConfigRequest calls time-out and do not take effect).

Fixes #1519

