### PR TITLE
Update .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,8 +5,7 @@ build:release --copt=-msse4.2
 # Options used to build with CUDA.
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
-
-build:cuda --action_env=TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.0,6.0,7.0,7.5,8.0"
+build:cuda --action_env=TF_CUDA_COMPUTE_CAPABILITIES="3.5,3.7,5.2,6.0,6.1,7.0"
 
 # Please note that MKL on MacOS or windows is still not supported.
 # If you would like to use a local MKL instead of downloading, please set the


### PR DESCRIPTION
Fix #1808 to specific correct capabilities to match up r2.3 release of serving:

https://github.com/tensorflow/serving/blob/0617d7acafcf4073e60bfbdaa2f624ed0b3e1808/.bazelrc#L8

Notably remove compute_80 as it only is available in cuda 11, and 2.2/3 releases use cuda 10.
