### PR TITLE
Remove an unused variable from HttpRestApiHandler::ProcessRequest

### DIFF
--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -69,7 +69,6 @@ Status HttpRestApiHandler::ProcessRequest(
   headers->clear();
   output->clear();
   AddHeaders(headers);
-  string model_version_str;
   string model_subresource;
   Status status = errors::InvalidArgument("Malformed request: ", http_method,
                                           " ", request_path);


### PR DESCRIPTION
This PR just removes an unused variable.