### PR TITLE
add cors headers in http response

### DIFF
--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -105,8 +105,6 @@ Status HttpRestApiHandler::ProcessRequest(
       status = ProcessModelStatusRequest(*model_name, model_version,
                                          model_version_label, output);
     }
-  } else if (http_method == "OPTIONS") {
-    status = Status::OK();
   }
 
   MakeJsonFromStatus(status, output);

--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -69,9 +69,6 @@ Status HttpRestApiHandler::ProcessRequest(
   headers->clear();
   output->clear();
   AddHeaders(headers);
-  if (core_->enable_cors_support()) {
-    AddCORSHeaders(headers);
-  }
   string model_version_str;
   string model_subresource;
   Status status = errors::InvalidArgument("Malformed request: ", http_method,

--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -69,6 +69,9 @@ Status HttpRestApiHandler::ProcessRequest(
   headers->clear();
   output->clear();
   AddHeaders(headers);
+  if (core_->enable_cors_headers()) {
+    AddCORSHeaders(headers);
+  }
   string model_version_str;
   string model_subresource;
   Status status = errors::InvalidArgument("Malformed request: ", http_method,

--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -105,6 +105,8 @@ Status HttpRestApiHandler::ProcessRequest(
       status = ProcessModelStatusRequest(*model_name, model_version,
                                          model_version_label, output);
     }
+  } else if (http_method == "OPTIONS") {
+    status = Status::OK();
   }
 
   MakeJsonFromStatus(status, output);

--- a/tensorflow_serving/model_servers/http_rest_api_handler.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_handler.cc
@@ -69,7 +69,7 @@ Status HttpRestApiHandler::ProcessRequest(
   headers->clear();
   output->clear();
   AddHeaders(headers);
-  if (core_->enable_cors_headers()) {
+  if (core_->enable_cors_support()) {
     AddCORSHeaders(headers);
   }
   string model_version_str;

--- a/tensorflow_serving/model_servers/http_rest_api_util.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_util.cc
@@ -35,7 +35,7 @@ void AddHeaders(std::vector<std::pair<string, string>>* headers) {
 
 void AddCORSHeaders(std::vector<std::pair<string, string>>* headers) {
   headers->push_back({"Access-Control-Allow-Origin", "*"});
-  headers->push_back({"Access-Control-Allow-Methods", "POST, GET, OPTIONS"});
+  headers->push_back({"Access-Control-Allow-Methods", "POST, GET"});
   headers->push_back({"Access-Control-Allow-Headers", "Content-Type"});
 }
 

--- a/tensorflow_serving/model_servers/http_rest_api_util.cc
+++ b/tensorflow_serving/model_servers/http_rest_api_util.cc
@@ -33,6 +33,12 @@ void AddHeaders(std::vector<std::pair<string, string>>* headers) {
   headers->push_back({"Content-Type", "application/json"});
 }
 
+void AddCORSHeaders(std::vector<std::pair<string, string>>* headers) {
+  headers->push_back({"Access-Control-Allow-Origin", "*"});
+  headers->push_back({"Access-Control-Allow-Methods", "POST, GET, OPTIONS"});
+  headers->push_back({"Access-Control-Allow-Headers", "Content-Type"});
+}
+
 Status FillModelSpecWithNameVersionAndLabel(
     const absl::string_view model_name,
     const absl::optional<int64>& model_version,

--- a/tensorflow_serving/model_servers/http_rest_api_util.h
+++ b/tensorflow_serving/model_servers/http_rest_api_util.h
@@ -33,6 +33,8 @@ const char* const kHTTPRestApiHandlerPathRegex = "(?i)/v1/.*";
 
 void AddHeaders(std::vector<std::pair<string, string>>* headers);
 
+void AddCORSHeaders(std::vector<std::pair<string, string>>* headers);
+
 Status FillModelSpecWithNameVersionAndLabel(
     const absl::string_view model_name,
     const absl::optional<int64>& model_version,

--- a/tensorflow_serving/model_servers/http_server.cc
+++ b/tensorflow_serving/model_servers/http_server.cc
@@ -167,10 +167,11 @@ class RestApiRequestDispatcher {
     if (req->http_method() == "OPTIONS") {
       absl::string_view origin_header = req->GetRequestHeader("Origin");
       if (RE2::PartialMatch(origin_header, "https?://")) {
+        output.clear();
         status = Status::OK();
       } else {
         status = errors::FailedPrecondition(
-            "Origin header not found in request: ", req->http_method());
+            "Origin header is missing in CORS preflight");
       }
     }
 

--- a/tensorflow_serving/model_servers/http_server.cc
+++ b/tensorflow_serving/model_servers/http_server.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow_serving/model_servers/http_rest_api_handler.h"
+#include "tensorflow_serving/model_servers/http_rest_api_util.h"
 #include "tensorflow_serving/model_servers/server_core.h"
 #include "tensorflow_serving/servables/tensorflow/util.h"
 #include "tensorflow_serving/util/net_http/server/public/httpserver.h"
@@ -126,7 +127,7 @@ class RequestExecutor final : public net_http::EventExecutor {
 class RestApiRequestDispatcher {
  public:
   RestApiRequestDispatcher(int timeout_in_ms, ServerCore* core)
-      : regex_(HttpRestApiHandler::kPathRegex) {
+      : regex_(HttpRestApiHandler::kPathRegex), core_(core) {
     RunOptions run_options = RunOptions();
     run_options.set_timeout_in_ms(timeout_in_ms);
     handler_.reset(new HttpRestApiHandler(run_options, core));
@@ -160,19 +161,23 @@ class RestApiRequestDispatcher {
     string output;
     VLOG(1) << "Processing HTTP request: " << req->http_method() << " "
             << req->uri_path() << " body: " << body.size() << " bytes.";
-    auto status =
-        handler_->ProcessRequest(req->http_method(), req->uri_path(), body,
-                                 &headers, &model_name, &method, &output);
 
+    Status status;
     if (req->http_method() == "OPTIONS") {
       absl::string_view origin_header = req->GetRequestHeader("Origin");
       if (RE2::PartialMatch(origin_header, "https?://")) {
-        output.clear();
         status = Status::OK();
       } else {
         status = errors::FailedPrecondition(
             "Origin header is missing in CORS preflight");
       }
+    } else {
+      status =
+          handler_->ProcessRequest(req->http_method(), req->uri_path(), body,
+                                   &headers, &model_name, &method, &output);
+    }
+    if (core_->enable_cors_support()) {
+      AddCORSHeaders(&headers);
     }
 
     const auto http_status = ToHTTPStatusCode(status);
@@ -195,6 +200,7 @@ class RestApiRequestDispatcher {
 
   const RE2 regex_;
   std::unique_ptr<HttpRestApiHandler> handler_;
+  ServerCore* core_;
 };
 
 }  // namespace

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
                        "set, will be auto set based on number of CPUs."),
       tensorflow::Flag("rest_api_timeout_in_ms", &options.http_timeout_in_ms,
                        "Timeout for HTTP/REST API calls."),
-      tensorflow::Flag("rest_api_enable_cors_headers", &options.enable_cors_headers,
+      tensorflow::Flag("rest_api_enable_cors_support", &options.enable_cors_support,
                        "Enable CORS headers in response"),
       tensorflow::Flag("enable_batching", &options.enable_batching,
                        "enable batching"),

--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -75,6 +75,8 @@ int main(int argc, char** argv) {
                        "set, will be auto set based on number of CPUs."),
       tensorflow::Flag("rest_api_timeout_in_ms", &options.http_timeout_in_ms,
                        "Timeout for HTTP/REST API calls."),
+      tensorflow::Flag("rest_api_enable_cors_headers", &options.enable_cors_headers,
+                       "Enable CORS headers in response"),
       tensorflow::Flag("enable_batching", &options.enable_batching,
                        "enable batching"),
       tensorflow::Flag(

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -300,7 +300,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   options.flush_filesystem_caches = server_options.flush_filesystem_caches;
   options.allow_version_labels_for_unavailable_models =
       server_options.allow_version_labels_for_unavailable_models;
-  options.enable_cors_headers = server_options.enable_cors_headers;
+  options.enable_cors_support = server_options.enable_cors_support;
 
   TF_RETURN_IF_ERROR(ServerCore::Create(std::move(options), &server_core_));
 

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -300,6 +300,7 @@ Status Server::BuildAndStart(const Options& server_options) {
   options.flush_filesystem_caches = server_options.flush_filesystem_caches;
   options.allow_version_labels_for_unavailable_models =
       server_options.allow_version_labels_for_unavailable_models;
+  options.enable_cors_headers = server_options.enable_cors_headers;
 
   TF_RETURN_IF_ERROR(ServerCore::Create(std::move(options), &server_core_));
 

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -51,6 +51,7 @@ class Server {
     tensorflow::int32 http_port = 0;
     tensorflow::int32 http_num_threads = 4.0 * port::NumSchedulableCPUs();
     tensorflow::int32 http_timeout_in_ms = 30000;  // 30 seconds.
+    bool enable_cors_headers = false;
 
     //
     // Model Server options.

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -51,7 +51,7 @@ class Server {
     tensorflow::int32 http_port = 0;
     tensorflow::int32 http_num_threads = 4.0 * port::NumSchedulableCPUs();
     tensorflow::int32 http_timeout_in_ms = 30000;  // 30 seconds.
-    bool enable_cors_headers = false;
+    bool enable_cors_support = false;
 
     //
     // Model Server options.

--- a/tensorflow_serving/model_servers/server_core.h
+++ b/tensorflow_serving/model_servers/server_core.h
@@ -190,6 +190,8 @@ class ServerCore : public Manager {
 
     // The prefix to append to the file system storage paths.
     std::string storage_path_prefix;
+
+    bool enable_cors_headers = false;
   };
 
   virtual ~ServerCore() = default;
@@ -265,6 +267,8 @@ class ServerCore : public Manager {
   predict_response_tensor_serialization_option() const {
     return options_.predict_response_tensor_serialization_option;
   }
+
+  bool enable_cors_headers() const { return options_.enable_cors_headers; }
 
  protected:
   ServerCore(Options options);

--- a/tensorflow_serving/model_servers/server_core.h
+++ b/tensorflow_serving/model_servers/server_core.h
@@ -191,7 +191,7 @@ class ServerCore : public Manager {
     // The prefix to append to the file system storage paths.
     std::string storage_path_prefix;
 
-    bool enable_cors_headers = false;
+    bool enable_cors_support = false;
   };
 
   virtual ~ServerCore() = default;
@@ -268,7 +268,7 @@ class ServerCore : public Manager {
     return options_.predict_response_tensor_serialization_option;
   }
 
-  bool enable_cors_headers() const { return options_.enable_cors_headers; }
+  bool enable_cors_support() const { return options_.enable_cors_support; }
 
  protected:
   ServerCore(Options options);

--- a/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
+++ b/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
@@ -105,6 +105,9 @@ bool EvHTTPServer::Initialize() {
     return false;
   }
 
+  evhttp_set_allowed_methods(ev_http_,
+                             EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD |
+                             EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS);
   evhttp_set_gencb(ev_http_, &DispatchEvRequestFn, this);
 
   return true;

--- a/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
+++ b/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
@@ -105,6 +105,10 @@ bool EvHTTPServer::Initialize() {
     return false;
   }
 
+  // By default libevents only allow GET, POST, HEAD, PUT, DELETE request
+  // we have to manually turn OPTIONS flag on
+  // documentation:
+  // (http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/http_8h.html)
   evhttp_set_allowed_methods(ev_http_,
                              EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD |
                              EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS);


### PR DESCRIPTION
I was making a chatbot webapp, and I found out that I cannot directly call tensorflow serving API because it's missing the CORS headers.
I thought it will be cool if my front-end app can directly call the tensorflow serving API without creating a load balancer.