### PR TITLE
[INTEL MKL] Fix TensorFlow serving build issue for MKL dockerfiles

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,7 +11,7 @@ build:cuda --action_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm
 # Please note that MKL on MacOS or windows is still not supported.
 # If you would like to use a local MKL instead of downloading, please set the
 # environment variable "TF_MKL_ROOT" every time before build.
-build:mkl --define=build_with_mkl=true --define=enable_mkl=true
+build:mkl --define=build_with_mkl=true --define=enable_mkl=true --define=build_with_openmp=true
 build:mkl --define=tensorflow_mkldnn_contraction_kernel=0
 
 # This config option is used to enable MKL-DNN open source library only,

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
@@ -16,7 +16,7 @@ FROM ubuntu:18.04 as base_build
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=HEAD
 
-LABEL maintainer="Clayne Robison <clayne.b.robison@intel.com>"
+LABEL maintainer="Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
 LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
 
@@ -93,6 +93,7 @@ RUN curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVI
 FROM base_build as binary_build
 # Build, and install TensorFlow Serving
 ARG TF_SERVING_BUILD_OPTIONS="--config=mkl --config=release"
+
 RUN echo "Building with build options: ${TF_SERVING_BUILD_OPTIONS}"
 ARG TF_SERVING_BAZEL_OPTIONS=""
 RUN echo "Building with Bazel options: ${TF_SERVING_BAZEL_OPTIONS}"
@@ -119,8 +120,8 @@ RUN bazel build --color=yes --curses=yes \
     /tmp/pip/tensorflow_serving_api-*.whl && \
     rm -rf /tmp/pip
 
-# Copy MKL libraries
-RUN cp /root/.cache/bazel/_bazel_root/*/external/mkl_linux/lib/* /usr/local/lib
+# Copy openmp libraries
+RUN cp /root/.cache/bazel/_bazel_root/*/execroot/tf_serving/bazel-out/k8-opt/bin/external/llvm_openmp/libiomp5.so /usr/local/lib/
 
 ENV LIBRARY_PATH '/usr/local/lib:$LIBRARY_PATH'
 ENV LD_LIBRARY_PATH '/usr/local/lib:$LD_LIBRARY_PATH'

--- a/tensorflow_serving/tools/docker/Dockerfile.mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.mkl
@@ -21,7 +21,7 @@ FROM ubuntu:18.04
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=head
 
-LABEL maintainer="Clayne Robison <clayne.b.robison@intel.com>"
+LABEL maintainer="Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
 LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
 
@@ -36,8 +36,6 @@ COPY --from=build_image /usr/local/bin/tensorflow_model_server /usr/bin/tensorfl
 
 # Install MKL libraries
 COPY --from=build_image /usr/local/lib/libiomp5.so /usr/local/lib
-COPY --from=build_image /usr/local/lib/libmklml_gnu.so /usr/local/lib
-COPY --from=build_image /usr/local/lib/libmklml_intel.so /usr/local/lib
 
 ENV LIBRARY_PATH '/usr/local/lib:$LIBRARY_PATH'
 ENV LD_LIBRARY_PATH '/usr/local/lib:$LD_LIBRARY_PATH'


### PR DESCRIPTION
This is really just #1818 for `r2.4` since cherry-pick is not the right way to do it and of course fixes #1797 for the release branch.

Here is how I built it:

```
docker build -f Dockerfile.devel-mkl --build-arg TF_SERVING_BAZEL_OPTIONS='--local_ram_resources=HOST_RAM*0.8 --local_cpu_resources=HOST_CPUS-4' --build-arg TF_SERVING_VERSION_GIT_BRANCH=r2.4 --build-arg TF_SERVING_VERSION_GIT_COMMIT=HEAD --build-arg BAZEL_VERSION=3.0.0 . -t tf-serving-not-based-on-ubuntu:intel-tf-serving-r2.4
```
and here is my output:
```
Step 1/29 : FROM ubuntu:18.04 as base_build
 ---> c090eaba6b94
Step 2/29 : ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ---> Using cache
 ---> 123f3b33ba2a
Step 3/29 : ARG TF_SERVING_VERSION_GIT_COMMIT=HEAD
 ---> Using cache
 ---> 67afd58aac1b
Step 4/29 : LABEL maintainer="Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>"
 ---> Using cache
 ---> b565933c12d8
Step 5/29 : LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
 ---> Using cache
 ---> b84b4533fa6d
Step 6/29 : LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
 ---> Using cache
 ---> 08887bfbc92b
Step 7/29 : RUN apt-get update && apt-get install -y --no-install-recommends         automake         build-essential         ca-certificates         curl         git         libcurl3-dev         libfreetype6-dev         libpng-dev         libtool         libzmq3-dev         mlocate         openjdk-8-jdk        openjdk-8-jre-headless         pkg-config         python-dev         software-properties-common         swig         unzip         wget         zip         zlib1g-dev         python3-distutils         &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> cbbf33120161
Step 8/29 : RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py &&     python3 get-pip.py &&     rm get-pip.py
 ---> Using cache
 ---> 506d127fe853
Step 9/29 : RUN add-apt-repository ppa:deadsnakes/ppa &&     apt-get update && apt-get install -y     python3.6 python3.6-dev python3-pip python3.6-venv &&     rm -rf /var/lib/apt/lists/* &&     python3.6 -m pip install pip --upgrade &&     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 0
 ---> Using cache
 ---> 5e22ce970724
Step 10/29 : RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 0
 ---> Using cache
 ---> 1d537179e1ad
Step 11/29 : RUN pip3 --no-cache-dir install     future>=0.17.1     grpcio     h5py     keras_applications>=1.0.8     keras_preprocessing>=1.1.0     mock     numpy     portpicker     requests     --ignore-installed six>=1.12.0
 ---> Using cache
 ---> 42926927b224
Step 12/29 : ENV BAZEL_VERSION 3.0.0
 ---> Using cache
 ---> a26eebc770a4
Step 13/29 : WORKDIR /
 ---> Using cache
 ---> 5f95cfd87cea
Step 14/29 : RUN mkdir /bazel &&     cd /bazel &&     curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh &&     curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE &&     chmod +x bazel-*.sh &&     ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh &&     cd / &&     rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 ---> Using cache
 ---> 3c8160b3ee0e
Step 15/29 : WORKDIR /tensorflow-serving
 ---> Using cache
 ---> b5fa6b104777
Step 16/29 : RUN curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
 ---> Using cache
 ---> c166a10ba5c1
Step 17/29 : FROM base_build as binary_build
 ---> c166a10ba5c1
Step 18/29 : ARG TF_SERVING_BUILD_OPTIONS="--config=mkl --config=release"
 ---> Using cache
 ---> 95c9a5100fc7
Step 19/29 : RUN echo "Building with build options: ${TF_SERVING_BUILD_OPTIONS}"
 ---> Using cache
 ---> 0af1c3572724
Step 20/29 : ARG TF_SERVING_BAZEL_OPTIONS=""
 ---> Using cache
 ---> 6299236fcf7f
Step 21/29 : RUN echo "Building with Bazel options: ${TF_SERVING_BAZEL_OPTIONS}"
 ---> Using cache
 ---> d56d9faac982
Step 22/29 : RUN bazel build --color=yes --curses=yes     ${TF_SERVING_BAZEL_OPTIONS}     --verbose_failures     --output_filter=DONT_MATCH_ANYTHING     ${TF_SERVING_BUILD_OPTIONS}     tensorflow_serving/model_servers:tensorflow_model_server &&     cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server     /usr/local/bin/
 ---> Using cache
 ---> e89879363431
Step 23/29 : RUN bazel build --color=yes --curses=yes     ${TF_SERVING_BAZEL_OPTIONS}     --verbose_failures     --output_filter=DONT_MATCH_ANYTHING     ${TF_SERVING_BUILD_OPTIONS}     tensorflow_serving/tools/pip_package:build_pip_package &&     bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package     /tmp/pip &&     pip --no-cache-dir install --upgrade     /tmp/pip/tensorflow_serving_api-*.whl &&     rm -rf /tmp/pip
 ---> Using cache
 ---> 7d1a8f12d4b3
Step 24/29 : RUN cp /root/.cache/bazel/_bazel_root/*/execroot/tf_serving/bazel-out/k8-opt/bin/external/llvm_openmp/libiomp5.so /usr/local/lib/
 ---> Using cache
 ---> e138ae44e1dd
Step 25/29 : ENV LIBRARY_PATH '/usr/local/lib:$LIBRARY_PATH'
 ---> Using cache
 ---> e60e8f66984a
Step 26/29 : ENV LD_LIBRARY_PATH '/usr/local/lib:$LD_LIBRARY_PATH'
 ---> Using cache
 ---> 95dc6068d753
Step 27/29 : FROM binary_build as clean_build
 ---> 95dc6068d753
Step 28/29 : RUN bazel clean --expunge --color=yes &&     rm -rf /root/.cache
 ---> Using cache
 ---> ee63face0722
Step 29/29 : CMD ["/bin/bash"]
 ---> Using cache
 ---> 2c284d1ea73d
Successfully built 2c284d1ea73d
Successfully tagged tf-serving-not-based-on-ubuntu:intel-tf-serving-r2.4
```
