### PR TITLE
Fix broken GPU build by adding TF cuda options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,10 @@ build:release --copt=-mavx
 build:release --copt=-msse4.2
 
 # Options used to build with CUDA.
+build:cuda --repo_env TF_NEED_CUDA=1
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
+build:cuda --@local_config_cuda//:enable_cuda
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
-
 build:cuda --action_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,compute_80"
 
 # Options used to build with TPU support.


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/blob/aa44812e3e40b1c95586466bc177b07525b787ea/.bazelrc#L227

to TF Serving. This causes TF sources to be built with correct
options (bazel options are not picked from relevant dependent
repo (TF in this case), when building code from that repo).

PiperOrigin-RevId: 369022405
(cherry picked from commit 46694d03ef9287d72f856b2a4a159381ff645815)