### PR TITLE
_TF_REQ is not compatible `tensorflow-cpu` requirements using pip

### DIFF
--- a/tensorflow_serving/tools/pip_package/setup.py
+++ b/tensorflow_serving/tools/pip_package/setup.py
@@ -44,7 +44,7 @@ if '--project_name' in sys.argv:
   sys.argv.remove('--project_name')
   sys.argv.pop(project_name_idx)
 
-_TF_REQ = ['tensorflow'+_TF_VERSION_SANITIZED]
+_TF_REQ = ['tensorflow-cpu'+_TF_VERSION_SANITIZED]
 
 # GPU build (note: the only difference is we depend on tensorflow-gpu so
 # pip doesn't overwrite it with the CPU build)


### PR DESCRIPTION
When `tensorflow-cpu` is already installed, `tensorflow-serving-api` package cannot detect tesnroflow installation.


`https://pypi.org/project/tensorflow-serving-api/` should follow `tensorflow-cpu`

`https://pypi.org/project/tensorflow-serving-api-gpu/` is now folloing `tensorflow-gpu` requirement.