### PR TITLE
[INTEL MKL] Fix Intel MKL TensorFlow Serving Container build

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
@@ -88,7 +88,9 @@ RUN mkdir /bazel && \
 
 # Download TF Serving sources (optionally at specific commit).
 WORKDIR /tensorflow-serving
-RUN curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
+RUN git clone --single-branch --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving /tensorflow-serving && \
+    cd /tensorflow-serving && \
+    git checkout ${TF_SERVING_VERSION_GIT_COMMIT}
 
 FROM base_build as binary_build
 # Build, and install TensorFlow Serving


### PR DESCRIPTION
Signed-off-by: Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>

For some reason when downloading repo with `curl` I get the following error while building `2.5.1` image for `Intel MKL`:

```
root@f881d27588d3:/tensorflow-serving# export TF_SERVING_BUILD_OPTIONS='--config=mkl --config=release'
root@f881d27588d3:/tensorflow-serving# export TF_SERVING_BAZEL_OPTIONS='--local_ram_resources=HOST_RAM*0.8 --local_cpu_resources=HOST_CPUS-4'

root@f881d27588d3:/tensorflow-serving# bazel build --color=yes --curses=yes \
>     ${TF_SERVING_BAZEL_OPTIONS} \
>     --verbose_failures \
>     --output_filter=DONT_MATCH_ANYTHING \
>     ${TF_SERVING_BUILD_OPTIONS} \
>     tensorflow_serving/model_servers:tensorflow_model_server
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
WARNING: Download from https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/53c3fc3e5a7cafc57e6644cbbbedea425a7b1db7.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
WARNING: Download from http://mirror.tensorflow.org/github.com/tensorflow/runtime/archive/aeff3dee47f4bd2e0044ecefc8e19dbd3fc21427.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
DEBUG: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/third_party/repo.bzl:109:14: 
Warning: skipping import of repository 'icu' because it already exists.
DEBUG: Rule 'io_bazel_rules_docker' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1596824487 -0400"
DEBUG: Repository io_bazel_rules_docker instantiated at:
  /tensorflow-serving/WORKSPACE:44:10: in <toplevel>
  /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/tensorflow/workspace0.bzl:108:34: in workspace
  /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/bazel_toolchains/repositories/repositories.bzl:35:23: in repositories
Repository rule git_repository defined at:
  /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
WARNING: Download from https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/12d04ce9569edec68220888e02aab4fc25e55e01.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
INFO: Analyzed target //tensorflow_serving/model_servers:tensorflow_model_server (281 packages loaded, 23465 targets configured).
INFO: Found 1 target...
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/tensorflow/core/common_runtime/BUILD:1663:11: Couldn't build file external/org_tensorflow/tensorflow/core/common_runtime/_objs/threadpool_device/threadpool_device.o: C++ compilation of rule '@org_tensorflow//tensorflow/core/common_runtime:threadpool_device' failed (Exit 1): gcc failed: error executing command 
  (cd /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/execroot/tf_serving && \
  exec env - \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    PWD=/proc/self/cwd \
  /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-std=c++11' -MD -MF bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/core/common_runtime/_objs/threadpool_device/threadpool_device.d '-frandom-seed=bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/core/common_runtime/_objs/threadpool_device/threadpool_device.o' -DTF_USE_SNAPPY -DEIGEN_MPL2_ONLY '-DEIGEN_MAX_ALIGN_BYTES=64' -DHAVE_SYS_UIO_H -iquoteexternal/org_tensorflow -iquotebazel-out/k8-opt/bin/external/org_tensorflow -iquoteexternal/com_google_absl -iquotebazel-out/k8-opt/bin/external/com_google_absl -iquoteexternal/nsync -iquotebazel-out/k8-opt/bin/external/nsync -iquoteexternal/eigen_archive -iquotebazel-out/k8-opt/bin/external/eigen_archive -iquoteexternal/gif -iquotebazel-out/k8-opt/bin/external/gif -iquoteexternal/libjpeg_turbo -iquotebazel-out/k8-opt/bin/external/libjpeg_turbo -iquoteexternal/com_google_protobuf -iquotebazel-out/k8-opt/bin/external/com_google_protobuf -iquoteexternal/zlib -iquotebazel-out/k8-opt/bin/external/zlib -iquoteexternal/com_googlesource_code_re2 -iquotebazel-out/k8-opt/bin/external/com_googlesource_code_re2 -iquoteexternal/farmhash_archive -iquotebazel-out/k8-opt/bin/external/farmhash_archive -iquoteexternal/fft2d -iquotebazel-out/k8-opt/bin/external/fft2d -iquoteexternal/highwayhash -iquotebazel-out/k8-opt/bin/external/highwayhash -iquoteexternal/double_conversion -iquotebazel-out/k8-opt/bin/external/double_conversion -iquoteexternal/snappy -iquotebazel-out/k8-opt/bin/external/snappy -isystem external/nsync/public -isystem bazel-out/k8-opt/bin/external/nsync/public -isystem external/org_tensorflow/third_party/eigen3/mkl_include -isystem bazel-out/k8-opt/bin/external/org_tensorflow/third_party/eigen3/mkl_include -isystem external/eigen_archive -isystem bazel-out/k8-opt/bin/external/eigen_archive -isystem external/gif -isystem bazel-out/k8-opt/bin/external/gif -isystem external/com_google_protobuf/src -isystem bazel-out/k8-opt/bin/external/com_google_protobuf/src -isystem external/zlib -isystem bazel-out/k8-opt/bin/external/zlib -isystem external/farmhash_archive/src -isystem bazel-out/k8-opt/bin/external/farmhash_archive/src -isystem external/double_conversion -isystem bazel-out/k8-opt/bin/external/double_conversion -mavx -msse4.2 '-std=c++14' '-D_GLIBCXX_USE_CXX11_ABI=0' -DEIGEN_AVOID_STL_ARRAY -Iexternal/gemmlowp -Wno-sign-compare '-ftemplate-depth=900' -fno-exceptions -DINTEL_MKL -DENABLE_MKL -DENABLE_ONEDNN_OPENMP -msse3 -DTENSORFLOW_MONOLITHIC_BUILD -pthread -fopenmp -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/org_tensorflow/tensorflow/core/common_runtime/threadpool_device.cc -o bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/core/common_runtime/_objs/threadpool_device/threadpool_device.o)
Execution platform: @local_execution_config_platform//:platform
external/org_tensorflow/tensorflow/core/common_runtime/threadpool_device.cc:19:10: fatal error: external/llvm_openmp/include/omp.h: No such file or directory
 #include "external/llvm_openmp/include/omp.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Target //tensorflow_serving/model_servers:tensorflow_model_server failed to build
INFO: Elapsed time: 651.619s, Critical Path: 286.55s
INFO: 9441 processes: 585 internal, 8856 local.
FAILED: Build did NOT complete successfully
```

However once the fresh repo branch is cloned inside container or during Docker build the build is always successfull.

It's worth noting that downloading repo by or cloning a single branch doesn't make a whole lot of any difference for the user.