### PR TITLE
Copy old client to new package and updated unit tests

### DIFF
--- a/tensorflow_serving/util/net_http/client/test_client/internal/BUILD
+++ b/tensorflow_serving/util/net_http/client/test_client/internal/BUILD
@@ -1,0 +1,27 @@
+# Description: a lightweight http client
+
+package(
+    default_visibility = [
+        "//tensorflow_serving/util/net_http:__subpackages__",
+    ],
+)
+
+licenses(["notice"])
+
+cc_library(
+    name = "evhttp_client",
+    srcs = [
+        "evhttp_connection.cc",
+    ],
+    hdrs = [
+        "evhttp_connection.h",
+    ],
+    deps = [
+        "//tensorflow_serving/util/net_http/client/test_client/public:http_client_api",
+        "//tensorflow_serving/util/net_http/internal:net_logging",
+        "//tensorflow_serving/util/net_http/server/public:http_server_api",
+        "@com_github_libevent_libevent//:libevent",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+    ],
+)

--- a/tensorflow_serving/util/net_http/client/test_client/internal/README.md
+++ b/tensorflow_serving/util/net_http/client/test_client/internal/README.md
@@ -1,0 +1,5 @@
+The client library is still under development, and has yet to be finalized.
+
+It should be primarily used for writing tests for users of the
+ServerRequestInterface and HTTPServerInterface APIs to verify basic
+functionality, and the current state should be considered experimental.

--- a/tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.cc
+++ b/tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.cc
@@ -1,0 +1,256 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// libevent based client implementation
+
+#include "tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h"
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow_serving/util/net_http/internal/net_logging.h"
+#include "tensorflow_serving/util/net_http/server/public/response_code_enum.h"
+
+namespace tensorflow {
+namespace serving {
+namespace net_http {
+
+TestEvHTTPConnection::~TestEvHTTPConnection() {
+  if (evcon_ != nullptr) {
+    evhttp_connection_free(evcon_);
+  }
+  if (http_uri_ != nullptr) {
+    evhttp_uri_free(http_uri_);
+  }
+
+  event_base_free(ev_base_);
+}
+
+// This needs be called with any async SendRequest()
+void TestEvHTTPConnection::Terminate() {
+  event_base_loopexit(ev_base_, nullptr);
+  if (loop_exit_ != nullptr) {
+    loop_exit_->WaitForNotification();
+  }
+}
+
+std::unique_ptr<TestEvHTTPConnection> TestEvHTTPConnection::Connect(
+    absl::string_view url) {
+  std::string url_str(url.data(), url.size());
+  struct evhttp_uri* http_uri = evhttp_uri_parse(url_str.c_str());
+  if (http_uri == nullptr) {
+    NET_LOG(ERROR, "Failed to connect : event_base_new()");
+    return nullptr;
+  }
+
+  const char* host = evhttp_uri_get_host(http_uri);
+  if (host == nullptr) {
+    NET_LOG(ERROR, "url must have a host %.*s", static_cast<int>(url.size()),
+            url.data());
+    return nullptr;
+  }
+
+  int port = evhttp_uri_get_port(http_uri);
+  if (port == -1) {
+    port = 80;
+  }
+
+  auto result = Connect(host, port);
+  evhttp_uri_free(http_uri);
+
+  return result;
+}
+
+std::unique_ptr<TestEvHTTPConnection> TestEvHTTPConnection::Connect(
+    absl::string_view host, int port) {
+  std::unique_ptr<TestEvHTTPConnection> result(new TestEvHTTPConnection());
+
+  result->ev_base_ = event_base_new();
+  if (result->ev_base_ == nullptr) {
+    NET_LOG(ERROR, "Failed to connect : event_base_new()");
+    return nullptr;
+  }
+
+  // blocking call (DNS resolution)
+  std::string host_str(host.data(), host.size());
+  result->evcon_ = evhttp_connection_base_bufferevent_new(
+      result->ev_base_, nullptr, nullptr, host_str.c_str(),
+      static_cast<uint16_t>(port));
+  if (result->evcon_ == nullptr) {
+    NET_LOG(ERROR,
+            "Failed to connect : evhttp_connection_base_bufferevent_new()");
+    return nullptr;
+  }
+
+  evhttp_connection_set_retries(result->evcon_, 0);
+
+  // TODO(wenboz): make this an option (default to 5s)
+  evhttp_connection_set_timeout(result->evcon_, 5);
+
+  return result;
+}
+
+namespace {
+
+// Copy ev response data to ClientResponse.
+void PopulateResponse(evhttp_request* req, TestClientResponse* response) {
+  response->status =
+      static_cast<HTTPStatusCode>(evhttp_request_get_response_code(req));
+
+  struct evkeyvalq* headers = evhttp_request_get_input_headers(req);
+  struct evkeyval* header;
+  for (header = headers->tqh_first; header; header = header->next.tqe_next) {
+    response->headers.emplace_back(header->key, header->value);
+  }
+
+  char buffer[1024];
+  int nread;
+
+  while ((nread = evbuffer_remove(evhttp_request_get_input_buffer(req), buffer,
+                                  sizeof(buffer))) > 0) {
+    absl::StrAppend(&response->body,
+                    absl::string_view(buffer, static_cast<size_t>(nread)));
+  }
+}
+
+evhttp_cmd_type GetMethodEnum(absl::string_view method, bool with_body) {
+  if (method.compare("GET") == 0) {
+    return EVHTTP_REQ_GET;
+  } else if (method.compare("POST") == 0) {
+    return EVHTTP_REQ_POST;
+  } else if (method.compare("HEAD") == 0) {
+    return EVHTTP_REQ_HEAD;
+  } else if (method.compare("PUT") == 0) {
+    return EVHTTP_REQ_PUT;
+  } else if (method.compare("DELETE") == 0) {
+    return EVHTTP_REQ_DELETE;
+  } else if (method.compare("OPTIONS") == 0) {
+    return EVHTTP_REQ_OPTIONS;
+  } else if (method.compare("TRACE") == 0) {
+    return EVHTTP_REQ_TRACE;
+  } else if (method.compare("CONNECT") == 0) {
+    return EVHTTP_REQ_CONNECT;
+  } else if (method.compare("PATCH") == 0) {
+    return EVHTTP_REQ_PATCH;
+  } else {
+    if (with_body) {
+      return EVHTTP_REQ_POST;
+    } else {
+      return EVHTTP_REQ_GET;
+    }
+  }
+}
+
+void ResponseDone(evhttp_request* req, void* ctx) {
+  TestClientResponse* response = reinterpret_cast<TestClientResponse*>(ctx);
+
+  if (req == nullptr) {
+    // TODO(wenboz): make this a util and check safety
+    int errcode = EVUTIL_SOCKET_ERROR();
+    NET_LOG(ERROR, "socket error = %s (%d)",
+            evutil_socket_error_to_string(errcode), errcode);
+    return;
+  }
+
+  PopulateResponse(req, response);
+
+  if (response->done != nullptr) {
+    response->done();
+  }
+}
+
+// Returns false if there is any error.
+bool GenerateEvRequest(evhttp_connection* evcon, const TestClientRequest& request,
+                       TestClientResponse* response) {
+  evhttp_request* evreq = evhttp_request_new(ResponseDone, response);
+  if (evreq == nullptr) {
+    NET_LOG(ERROR, "Failed to send request : evhttp_request_new()");
+    return false;
+  }
+
+  evkeyvalq* output_headers = evhttp_request_get_output_headers(evreq);
+  for (auto header : request.headers) {
+    std::string key(header.first.data(), header.first.size());
+    std::string value(header.second.data(), header.second.size());
+    evhttp_add_header(output_headers, key.c_str(), value.c_str());
+  }
+
+  evhttp_add_header(output_headers, "Connection", "close");
+
+  if (!request.body.empty()) {
+    evbuffer* output_buffer = evhttp_request_get_output_buffer(evreq);
+
+    std::string body(request.body.data(), request.body.size());
+    evbuffer_add(output_buffer, body.c_str(), request.body.size());
+
+    char length_header[16];
+    evutil_snprintf(length_header, sizeof(length_header) - 1, "%lu",
+                    request.body.size());
+    evhttp_add_header(output_headers, "Content-Length", length_header);
+  }
+
+  std::string uri(request.uri_path.data(), request.uri_path.size());
+  int r = evhttp_make_request(
+      evcon, evreq, GetMethodEnum(request.method, !request.body.empty()),
+      uri.c_str());
+  if (r != 0) {
+    NET_LOG(ERROR, "evhttp_make_request() failed");
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+// Sends the request and has the connection closed
+bool TestEvHTTPConnection::BlockingSendRequest(const TestClientRequest& request,
+                                           TestClientResponse* response) {
+  if (!GenerateEvRequest(evcon_, request, response)) {
+    NET_LOG(ERROR, "Failed to generate the ev_request");
+    return false;
+  }
+
+  // inline loop blocking
+  event_base_dispatch(ev_base_);
+  return true;
+}
+
+bool TestEvHTTPConnection::SendRequest(const TestClientRequest& request,
+                                   TestClientResponse* response) {
+  if (this->executor_ == nullptr) {
+    NET_LOG(ERROR, "EventExecutor is not configured.");
+    return false;
+  }
+
+  if (!GenerateEvRequest(evcon_, request, response)) {
+    NET_LOG(ERROR, "Failed to generate the ev_request");
+    return false;
+  }
+
+  executor_->Schedule([this]() {
+    loop_exit_.reset(new absl::Notification());
+    event_base_dispatch(ev_base_);
+    loop_exit_->Notify();
+  });
+
+  return true;
+}
+
+void TestEvHTTPConnection::SetExecutor(std::unique_ptr<EventExecutor> executor) {
+  this->executor_ = std::move(executor);
+}
+
+}  // namespace net_http
+}  // namespace serving
+}  // namespace tensorflow

--- a/tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h
+++ b/tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h
@@ -1,0 +1,103 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_INTERNAL_EVHTTP_CONNECTION_H_
+#define TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_INTERNAL_EVHTTP_CONNECTION_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/notification.h"
+
+#include "libevent/include/event2/buffer.h"
+#include "libevent/include/event2/bufferevent.h"
+#include "libevent/include/event2/event.h"
+#include "libevent/include/event2/http.h"
+#include "libevent/include/event2/keyvalq_struct.h"
+#include "libevent/include/event2/util.h"
+
+// TODO(wenboz): move EventExecutor to net_http/common
+#include "tensorflow_serving/util/net_http/client/test_client/public/httpclient_interface.h"
+#include "tensorflow_serving/util/net_http/server/public/httpserver_interface.h"
+
+namespace tensorflow {
+namespace serving {
+namespace net_http {
+
+// The following types may be moved to an API interface in future.
+
+class TestEvHTTPConnection final : public TestHTTPClientInterface {
+ public:
+  TestEvHTTPConnection() = default;
+
+  ~TestEvHTTPConnection() override;
+
+  TestEvHTTPConnection(const TestEvHTTPConnection& other) = delete;
+  TestEvHTTPConnection& operator=(const TestEvHTTPConnection& other) = delete;
+
+  // Terminates the connection.
+  void Terminate() override;
+
+  // Returns a new connection given an absolute URL.
+  // Always treat the URL scheme as "http" for now.
+  // Returns nullptr if any error
+  static std::unique_ptr<TestEvHTTPConnection> Connect(absl::string_view url);
+
+  // Returns a new connection to the specified host:port.
+  // Returns nullptr if any error
+  static std::unique_ptr<TestEvHTTPConnection> Connect(absl::string_view host,
+                                                   int port);
+
+  // Returns a new connection to the specified port of localhost.
+  // Returns nullptr if any error
+  static std::unique_ptr<TestEvHTTPConnection> ConnectLocal(int port) {
+    return Connect("localhost", port);
+  }
+
+  // Sends a request and blocks the caller till a response is received
+  // or any error has happened.
+  // Returns false if any error.
+  bool BlockingSendRequest(const TestClientRequest& request,
+                           TestClientResponse* response) override;
+
+  // Sends a request and returns immediately. The response will be handled
+  // asynchronously via the response->done callback.
+  // Returns false if any error in sending the request, or if the executor
+  // has not been configured.
+  bool SendRequest(const TestClientRequest& request,
+                   TestClientResponse* response) override;
+
+  // Sets the executor for processing requests asynchronously.
+  void SetExecutor(std::unique_ptr<EventExecutor> executor) override;
+
+ private:
+  struct event_base* ev_base_;
+  struct evhttp_uri* http_uri_;
+  struct evhttp_connection* evcon_;
+
+  std::unique_ptr<EventExecutor> executor_;
+
+  std::unique_ptr<absl::Notification> loop_exit_;
+};
+
+}  // namespace net_http
+}  // namespace serving
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_INTERNAL_EVHTTP_CONNECTION_H_

--- a/tensorflow_serving/util/net_http/client/test_client/public/BUILD
+++ b/tensorflow_serving/util/net_http/client/test_client/public/BUILD
@@ -1,0 +1,38 @@
+# Description: APIs for experimental testing of net_http server instances
+
+package(
+    default_visibility = [
+        ":http_client_users",
+        "//tensorflow_serving/util/net_http:__subpackages__",
+    ],
+)
+
+package_group(
+    name = "http_client_users",
+    packages = [
+        "//third_party/ecclesia/...",
+    ],
+)
+
+licenses(["notice"])
+
+cc_library(
+    name = "http_client_api",
+    srcs = [],
+    hdrs = [
+        "httpclient_interface.h",
+    ],
+    deps = ["//tensorflow_serving/util/net_http/server/public:http_server_api"],
+)
+
+cc_library(
+    name = "http_client",
+    hdrs = [
+        "httpclient.h",
+    ],
+    deps = [
+        ":http_client_api",
+        "//tensorflow_serving/util/net_http/client/test_client/internal:evhttp_client",
+        "@com_google_absl//absl/memory",
+    ],
+)

--- a/tensorflow_serving/util/net_http/client/test_client/public/README.md
+++ b/tensorflow_serving/util/net_http/client/test_client/public/README.md
@@ -1,0 +1,5 @@
+The client library is still under development, and has yet to be finalized.
+
+It should be primarily used for writing tests for users of the
+ServerRequestInterface and HTTPServerInterface APIs to verify basic
+functionality, and the current state should be considered experimental.

--- a/tensorflow_serving/util/net_http/client/test_client/public/httpclient.h
+++ b/tensorflow_serving/util/net_http/client/test_client/public/httpclient.h
@@ -1,0 +1,48 @@
+/* Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_H_
+#define THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_H_
+
+#include "absl/memory/memory.h"
+#include "tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h"
+#include "tensorflow_serving/util/net_http/client/test_client/public/httpclient_interface.h"
+
+// Factory to manage internal dependency
+// NOTE: This API is not yet finalized, and should in its current state be
+// considered experimental
+
+namespace tensorflow {
+namespace serving {
+namespace net_http {
+
+// Creates a connection to a server implemented based on the libevents library.
+// Returns nullptr if there is any error.
+inline std::unique_ptr<TestHTTPClientInterface> CreateEvHTTPConnection(
+    absl::string_view host, int port) {
+  auto connection = absl::make_unique<TestEvHTTPConnection>();
+  connection = connection->Connect(host, port);
+  if (!connection) {
+    return nullptr;
+  }
+
+  return std::move(connection);
+}
+
+}  // namespace net_http
+}  // namespace serving
+}  // namespace tensorflow
+
+#endif  // THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_H_

--- a/tensorflow_serving/util/net_http/client/test_client/public/httpclient_interface.h
+++ b/tensorflow_serving/util/net_http/client/test_client/public/httpclient_interface.h
@@ -1,0 +1,85 @@
+/* Copyright 2020 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_INTERFACE_H_
+#define THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_INTERFACE_H_
+
+#include "tensorflow_serving/util/net_http/server/public/httpserver_interface.h"
+#include "tensorflow_serving/util/net_http/server/public/response_code_enum.h"
+
+// API for the HTTP Client
+// NOTE: This API is not yet finalized, and should be considered experimental.
+
+namespace tensorflow {
+namespace serving {
+namespace net_http {
+
+// Data to be copied
+struct TestClientRequest {
+  typedef std::pair<absl::string_view, absl::string_view> HeaderKeyValue;
+
+  absl::string_view uri_path;
+  absl::string_view method;  // must be in upper-case
+  std::vector<HeaderKeyValue> headers;
+  absl::string_view body;
+};
+
+// Caller allocates the data for output
+struct TestClientResponse {
+  typedef std::pair<std::string, std::string> HeaderKeyValue;
+
+  HTTPStatusCode status = HTTPStatusCode::UNDEFINED;
+  std::vector<HeaderKeyValue> headers;
+  std::string body;
+
+  std::function<void()> done;  // callback
+};
+
+// This interface class specifies the API contract for the HTTP client.
+class TestHTTPClientInterface {
+ public:
+  TestHTTPClientInterface(const TestHTTPClientInterface& other) = delete;
+  TestHTTPClientInterface& operator=(const TestHTTPClientInterface& other) = delete;
+
+  virtual ~TestHTTPClientInterface() = default;
+
+  // Terminates the connection.
+  virtual void Terminate() = 0;
+
+  // Sends a request and blocks the caller till a response is received
+  // or any error has happened.
+  // Returns false if any error.
+  virtual bool BlockingSendRequest(const TestClientRequest& request,
+                                   TestClientResponse* response) = 0;
+
+  // Sends a request and returns immediately. The response will be handled
+  // asynchronously via the response->done callback.
+  // Returns false if any error in sending the request, or if the executor
+  // has not been configured.
+  virtual bool SendRequest(const TestClientRequest& request,
+                           TestClientResponse* response) = 0;
+
+  // Sets the executor for processing requests asynchronously.
+  virtual void SetExecutor(std::unique_ptr<EventExecutor> executor) = 0;
+
+ protected:
+  TestHTTPClientInterface() = default;
+};
+
+}  // namespace net_http
+}  // namespace serving
+}  // namespace tensorflow
+
+#endif  // THIRD_PARTY_TENSORFLOW_SERVING_UTIL_NET_HTTP_CLIENT_TEST_CLIENT_PUBLIC_HTTPCLIENT_INTERFACE_H_

--- a/tensorflow_serving/util/net_http/client/test_client/testing/BUILD
+++ b/tensorflow_serving/util/net_http/client/test_client/testing/BUILD
@@ -1,0 +1,15 @@
+# Description: net_http/client/test_client/testing
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "evhttp_echo_client",
+    srcs = ["evhttp_echo_client.cc"],
+    deps = [
+        "//tensorflow_serving/util/net_http/client/test_client/internal:evhttp_client",
+    ],
+)

--- a/tensorflow_serving/util/net_http/client/test_client/testing/evhttp_echo_client.cc
+++ b/tensorflow_serving/util/net_http/client/test_client/testing/evhttp_echo_client.cc
@@ -1,0 +1,63 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// A test client to print the response from the evhttp_echo_server
+// URI: /print
+
+#include <iostream>
+
+#include "tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h"
+
+namespace {
+
+using tensorflow::serving::net_http::TestClientRequest;
+using tensorflow::serving::net_http::TestClientResponse;
+using tensorflow::serving::net_http::TestEvHTTPConnection;
+
+bool SendRequest(const char* url) {
+  auto connection = TestEvHTTPConnection::Connect(url);
+  if (connection == nullptr) {
+    std::cerr << "Fail to connect to %s" << url;
+  }
+
+  TestClientRequest request = {url, "GET", {}, ""};
+  TestClientResponse response = {};
+
+  if (!connection->BlockingSendRequest(request, &response)) {
+    std::cerr << "Request failed.";
+    return false;
+  }
+
+  std::cout << "Response received: " << std::endl
+            << "Status: " << static_cast<int>(response.status) << std::endl;
+
+  for (const auto& keyval : response.headers) {
+    std::cout << keyval.first << " : " << keyval.second << std::endl;
+  }
+
+  std::cout << std::endl << response.body << std::endl;
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: http-client <url>" << std::endl;
+    return 1;
+  }
+
+  return SendRequest(argv[1]);
+}

--- a/tensorflow_serving/util/net_http/server/internal/BUILD
+++ b/tensorflow_serving/util/net_http/server/internal/BUILD
@@ -42,7 +42,7 @@ cc_test(
     deps = [
         ":evhttp_server",
         "//tensorflow_serving/core/test_util:test_main",
-        "//tensorflow_serving/util/net_http/client/internal:evhttp_client",
+        "//tensorflow_serving/util/net_http/client/test_client/internal:evhttp_client",
         "//tensorflow_serving/util/net_http/internal:fixed_thread_pool",
         "//tensorflow_serving/util/net_http/server/public:http_server",
         "//tensorflow_serving/util/net_http/server/public:http_server_api",
@@ -59,7 +59,7 @@ cc_test(
     deps = [
         ":evhttp_server",
         "//tensorflow_serving/core/test_util:test_main",
-        "//tensorflow_serving/util/net_http/client/internal:evhttp_client",
+        "//tensorflow_serving/util/net_http/client/test_client/internal:evhttp_client",
         "//tensorflow_serving/util/net_http/compression:gzip_zlib",
         "//tensorflow_serving/util/net_http/internal:fixed_thread_pool",
         "//tensorflow_serving/util/net_http/server/public:http_server",

--- a/tensorflow_serving/util/net_http/server/internal/evhttp_request_test.cc
+++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request_test.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/memory/memory.h"
-#include "tensorflow_serving/util/net_http/client/internal/evhttp_connection.h"
+#include "tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h"
 #include "tensorflow_serving/util/net_http/compression/gzip_zlib.h"
 #include "tensorflow_serving/util/net_http/internal/fixed_thread_pool.h"
 #include "tensorflow_serving/util/net_http/server/internal/evhttp_server.h"
@@ -76,11 +76,11 @@ TEST_F(EvHTTPRequestTest, SimpleGETNotFound) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/noop", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/noop", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::NOT_FOUND);
@@ -101,11 +101,11 @@ TEST_F(EvHTTPRequestTest, SimpleGETOK) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -131,11 +131,11 @@ TEST_F(EvHTTPRequestTest, SimplePOST) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, "abcde"};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "POST", {}, "abcde"};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -171,12 +171,12 @@ TEST_F(EvHTTPRequestTest, RequestUri) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
   for (const char* path : kUriPath) {
-    ClientRequest request = {path, "GET", {}, ""};
-    ClientResponse response = {};
+    TestClientRequest request = {path, "GET", {}, ""};
+    TestClientResponse response = {};
 
     EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   }
@@ -200,15 +200,15 @@ TEST_F(EvHTTPRequestTest, RequestHeaders) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok",
+  TestClientRequest request = {"/ok",
                            "GET",
-                           {ClientRequest::HeaderKeyValue("H1", "v1"),
-                            ClientRequest::HeaderKeyValue("H2", "v2")},
+                           {TestClientRequest::HeaderKeyValue("H1", "v1"),
+                            TestClientRequest::HeaderKeyValue("H2", "v2")},
                            ""};
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -232,11 +232,11 @@ TEST_F(EvHTTPRequestTest, ResponseHeaders) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   for (auto keyvalue : response.headers) {
@@ -272,12 +272,12 @@ TEST_F(EvHTTPRequestTest, InvalidGzipPost) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, "abcde"};
+  TestClientRequest request = {"/ok", "POST", {}, "abcde"};
   request.headers.emplace_back("Content-Encoding", "my_gzip");
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -301,12 +301,12 @@ TEST_F(EvHTTPRequestTest, DisableGzipPost) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, "abcde"};
+  TestClientRequest request = {"/ok", "POST", {}, "abcde"};
   request.headers.emplace_back("Content-Encoding", "my_gzip");
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -352,12 +352,12 @@ TEST_F(EvHTTPRequestTest, ValidGzipPost) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, compressed};
+  TestClientRequest request = {"/ok", "POST", {}, compressed};
   request.headers.emplace_back("Content-Encoding", "my_gzip");
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -389,12 +389,12 @@ TEST_F(EvHTTPRequestTest, GzipExceedingLimit) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, compressed};
+  TestClientRequest request = {"/ok", "POST", {}, compressed};
   request.headers.emplace_back("Content-Encoding", "my_gzip");
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -439,12 +439,12 @@ TEST_F(EvHTTPRequestTest, LargeGzipPost) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "POST", {}, compressed};
+  TestClientRequest request = {"/ok", "POST", {}, compressed};
   request.headers.emplace_back("Content-Encoding", "my_gzip");
-  ClientResponse response = {};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);

--- a/tensorflow_serving/util/net_http/server/internal/evhttp_server_test.cc
+++ b/tensorflow_serving/util/net_http/server/internal/evhttp_server_test.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/memory/memory.h"
 #include "absl/synchronization/notification.h"
-#include "tensorflow_serving/util/net_http/client/internal/evhttp_connection.h"
+#include "tensorflow_serving/util/net_http/client/test_client/internal/evhttp_connection.h"
 #include "tensorflow_serving/util/net_http/internal/fixed_thread_pool.h"
 #include "tensorflow_serving/util/net_http/server/public/httpserver.h"
 #include "tensorflow_serving/util/net_http/server/public/httpserver_interface.h"
@@ -92,11 +92,11 @@ TEST_F(EvHTTPServerTest, ExactPathMatching) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok?a=foo", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok?a=foo", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -131,11 +131,11 @@ TEST_F(EvHTTPServerTest, RequestHandlerOverwriting) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -161,11 +161,11 @@ TEST_F(EvHTTPServerTest, SingleRequestDispather) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -199,11 +199,11 @@ TEST_F(EvHTTPServerTest, UriPrecedesOverRequestDispather) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -244,11 +244,11 @@ TEST_F(EvHTTPServerTest, InOrderRequestDispather) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->BlockingSendRequest(request, &response));
   EXPECT_EQ(response.status, HTTPStatusCode::OK);
@@ -273,13 +273,13 @@ TEST_F(EvHTTPServerTest, RequestHandlerInteraction) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
   connection->SetExecutor(absl::make_unique<MyExecutor>(4));
 
   absl::Notification response_done;
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
   response.done = [&response_done]() { response_done.Notify(); };
 
   EXPECT_TRUE(connection->SendRequest(request, &response));
@@ -316,12 +316,12 @@ TEST_F(EvHTTPServerTest, ActiveRequestCountInShutdown) {
   server->StartAcceptingRequests();
 
   auto connection =
-      EvHTTPConnection::Connect("localhost", server->listen_port());
+      TestEvHTTPConnection::Connect("localhost", server->listen_port());
   ASSERT_TRUE(connection != nullptr);
   connection->SetExecutor(absl::make_unique<MyExecutor>(4));
 
-  ClientRequest request = {"/ok", "GET", {}, ""};
-  ClientResponse response = {};
+  TestClientRequest request = {"/ok", "GET", {}, ""};
+  TestClientResponse response = {};
 
   EXPECT_TRUE(connection->SendRequest(request, &response));
   handler_enter.WaitForNotification();


### PR DESCRIPTION
Copied the old client to the new “test_client” package and updated all the unit tests that use this client. Also added 'Test' Prefix to all classes and structs. All this is done to clear space for the development of a new public http client API. @wenbozhu will help upgrade all existing google-internal call sites of the old client. After that, I will delete everything directly under net_http/client. 