### PR TITLE
pass servable_versions_always_present via a flag

### DIFF
--- a/tensorflow_serving/model_servers/main.cc
+++ b/tensorflow_serving/model_servers/main.cc
@@ -261,8 +261,12 @@ int main(int argc, char** argv) {
       tensorflow::Flag("thread_pool_factory_config_file",
                        &options.thread_pool_factory_config_file,
                        "If non-empty, read an ascii ThreadPoolConfig protobuf "
-                       "from the supplied file name.")};
-
+                       "from the supplied file name."),
+      tensorflow::Flag("servable_versions_always_present",
+                       &options.servable_versions_always_present,
+                       "If true, the servable is always expected to exist on "
+                       "the underlying filesystem.")};
+      
   const auto& usage = tensorflow::Flags::Usage(argv[0], flag_list);
   if (!tensorflow::Flags::Parse(&argc, argv, flag_list)) {
     std::cout << usage;

--- a/tensorflow_serving/model_servers/server.cc
+++ b/tensorflow_serving/model_servers/server.cc
@@ -323,6 +323,8 @@ Status Server::BuildAndStart(const Options& server_options) {
   options.force_allow_any_version_labels_for_unavailable_models =
       server_options.force_allow_any_version_labels_for_unavailable_models;
   options.enable_cors_support = server_options.enable_cors_support;
+  options.servable_versions_always_present =
+      server_options.servable_versions_always_present;
 
   TF_RETURN_IF_ERROR(ServerCore::Create(std::move(options), &server_core_));
 

--- a/tensorflow_serving/model_servers/server.h
+++ b/tensorflow_serving/model_servers/server.h
@@ -100,6 +100,7 @@ class Server {
     tensorflow::string thread_pool_factory_config_file;
     bool enable_signature_method_name_check = false;
     bool enable_profiler = true;
+    bool servable_versions_always_present = false;
 
     Options();
   };


### PR DESCRIPTION
Expose `servable_versions_always_present` via a flag. As we ran into a similar issue described in https://github.com/tensorflow/serving/issues/1480