### PR TITLE
Fixing broken link in signature_defs.md

### DIFF
--- a/tensorflow_serving/g3doc/signature_defs.md
+++ b/tensorflow_serving/g3doc/signature_defs.md
@@ -20,7 +20,7 @@ function and can be specified when building a
 and
 [SessionBundle](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/session_bundle/session_bundle.h)
 used
-[Signatures](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/session_bundle/manifest.proto)
+[Signatures](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/session_bundle/oss/manifest.proto)
 which are similar in concept but required users to distinguish between named and
 default signatures in order for them to be retrieved correctly upon a load. For
 those who previously used TF-Exporter/SessionBundle, `Signatures` in TF-Exporter


### PR DESCRIPTION
Fixing a broken link for `signatures` in [this section](https://www.tensorflow.org/tfx/serving/signature_defs#background) with the correct URL.