### PR TITLE
Updating link for GPU docker file

### DIFF
--- a/tensorflow_serving/g3doc/setup.md
+++ b/tensorflow_serving/g3doc/setup.md
@@ -195,7 +195,7 @@ In order to build a custom version of TensorFlow Serving with GPU support, we
 recommend either building with the
 [provided Docker images](building_with_docker.md), or following the approach in
 the
-[GPU Dockerfile](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.devel-gpu).
+[GPU Dockerfile](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.gpu).
 
 ## TensorFlow Serving Python API PIP package
 


### PR DESCRIPTION
Updating link for GPU docker file from "https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.devel-gpu" to "https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.gpu". 

Reference Issue: https://github.com/tensorflow/serving/issues/2053