### PR TITLE
Add Intel OpenMP for MKL build since it's required now

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
@@ -66,6 +66,7 @@ RUN python -m pip --no-cache-dir install \
     'future>=0.17.1' \
     grpcio \
     h5py \
+    intel-openmp \
     'keras_applications>=1.0.8' \
     'keras_preprocessing>=1.1.0' \
     mock \
@@ -73,6 +74,8 @@ RUN python -m pip --no-cache-dir install \
     portpicker \
     requests \
     --ignore-installed 'six>=1.12.0'
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
 # Set up Bazel
 ENV BAZEL_VERSION 5.3.0


### PR DESCRIPTION
Signed-off-by: Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>

Looks like TF Serving + MKL now looks for `libiomp5.so` and if not found we get an error as follows:
```
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/tensorflow/cc/BUILD:681:22: Executing genrule @org_tensorflow//tensorflow/cc:candidate_sampling_ops_genrule failed: (Exit 127): bash failed: error executing command 
  (cd /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/execroot/tf_serving && \
  exec env - \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  /bin/bash bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/cc/candidate_sampling_ops_genrule.genrule_script.sh)
# Configuration: 165ec08304a7eacebdd9f7b599483e991b9b7887aabba1f02a76b171a0e1db4c
# Execution platform: @local_execution_config_platform//:platform
bazel-out/host/bin/external/org_tensorflow/tensorflow/cc/ops/candidate_sampling_ops_gen_cc: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/tensorflow/cc/BUILD:681:22: Executing genrule @org_tensorflow//tensorflow/cc:nn_ops_genrule failed: (Exit 127): bash failed: error executing command 
  (cd /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/execroot/tf_serving && \
  exec env - \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  /bin/bash bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/cc/nn_ops_genrule.genrule_script.sh)
# Configuration: 165ec08304a7eacebdd9f7b599483e991b9b7887aabba1f02a76b171a0e1db4c
# Execution platform: @local_execution_config_platform//:platform
bazel-out/host/bin/external/org_tensorflow/tensorflow/cc/ops/nn_ops_gen_cc: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
ERROR: /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/external/org_tensorflow/tensorflow/compiler/tf2xla/cc/BUILD:9:21: Executing genrule @org_tensorflow//tensorflow/compiler/tf2xla/cc:xla_ops_gen_genrule failed: (Exit 127): bash failed: error executing command 
  (cd /root/.cache/bazel/_bazel_root/e53bbb0b0da4e26d24b415310219b953/execroot/tf_serving && \
  exec env - \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; bazel-out/host/bin/external/org_tensorflow/tensorflow/compiler/tf2xla/cc/ops/xla_ops_gen_cc bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/compiler/tf2xla/cc/ops/xla_ops.h bazel-out/k8-opt/bin/external/org_tensorflow/tensorflow/compiler/tf2xla/cc/ops/xla_ops.cc 0 ,')
# Configuration: 165ec08304a7eacebdd9f7b599483e991b9b7887aabba1f02a76b171a0e1db4c
# Execution platform: @local_execution_config_platform//:platform
bazel-out/host/bin/external/org_tensorflow/tensorflow/compiler/tf2xla/cc/ops/xla_ops_gen_cc: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
```

This PR fixes that issue.

As before to build the TensorFlow Serving with MKL please see my notes here:
https://github.com/tensorflow/serving/pull/2077#issuecomment-1307535892
