### PR TITLE
Increase rate limit, override stale and remove stale to false for stale Github action. 

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -26,7 +26,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -33,6 +33,14 @@ jobs:
     steps:
     - uses: 'actions/stale@v7'
       with:
+        #Comma separated list of labels that can be assigned to issues to exclude them from being marked as stale 
+        exempt-issue-labels: 'override-stale' 
+        #Comma separated list of labels that can be assigned to PRs to exclude them from being marked as stale 
+        exempt-pr-labels: "override-stale" 
+        #Limit the No. of API calls in one run default value is 30. 
+        operations-per-run: 1000 
+        #Prevent to remove stale label when PRs or issues are updated. 
+        remove-stale-when-updated: false
         # comment on issue if not active for more then 7 days.
         stale-issue-message: 'This issue has been marked stale because it has no recent activity since 7 days. It will be closed if no further activity occurs. Thank you.'
         # comment on PR if not active for more then 14 days.
@@ -47,10 +55,6 @@ jobs:
         days-before-issue-close: 7
         # reason for closed the issue default value is not_planned
         close-issue-reason: completed
-        # Comma separated list of labels that can be assigned to issues to exclude them from being marked as stale
-        exempt-issue-labels: 'override-stale'
-        # Comma separated list of labels that can be assigned to PRs to exclude them from being marked as stale
-        exempt-pr-labels: "override-stale"
         # Number of days of inactivity before a stale PR is closed
         days-before-pr-close: 14
         # Number of days of inactivity before an PR Request becomes stale


### PR DESCRIPTION
In this PR:
Increased the no. of operations per run from 30 to 1000 to pick more issues and PRs.
Add Override stale .
Prevent to remove stale label when issues/PRs update.