### PR TITLE
Upgrade to ubuntu20.04 for docker images, which defaults to gcc-9.

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile
+++ b/tensorflow_serving/tools/docker/Dockerfile
@@ -16,10 +16,11 @@ ARG TF_SERVING_VERSION=latest
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel
 
 FROM ${TF_SERVING_BUILD_IMAGE} as build_image
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=head
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="gvasudevan@google.com"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:18.04 as base_build
+FROM ubuntu:20.04 as base_build
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=HEAD
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer=gvasudevan@google.com
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM nvidia/cuda:11.2.1-base-ubuntu18.04 as base_build
+FROM nvidia/cuda:11.2.1-base-ubuntu20.04 as base_build
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=HEAD
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer=gvasudevan@google.com
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-mkl
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:18.04 as base_build
+FROM ubuntu:20.04 as base_build
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=HEAD
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}

--- a/tensorflow_serving/tools/docker/Dockerfile.gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.gpu
@@ -16,10 +16,11 @@ ARG TF_SERVING_VERSION=latest
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE} as build_image
-FROM nvidia/cuda:11.2.1-base-ubuntu18.04
+FROM nvidia/cuda:11.2.1-base-ubuntu20.04
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=head
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="gvasudevan@google.com"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}

--- a/tensorflow_serving/tools/docker/Dockerfile.mkl
+++ b/tensorflow_serving/tools/docker/Dockerfile.mkl
@@ -16,10 +16,11 @@ ARG TF_SERVING_VERSION=latest
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-mkl
 
 FROM ${TF_SERVING_BUILD_IMAGE} as build_image
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG TF_SERVING_VERSION_GIT_BRANCH=master
 ARG TF_SERVING_VERSION_GIT_COMMIT=head
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}


### PR DESCRIPTION
PiperOrigin-RevId: 488422181
(cherry picked from commit d8555724ed54f3102952f9eca5a7d2b695899e20)