### PR TITLE
Remove 'awaiting' labels when user issue/PR updated.

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -39,7 +39,9 @@ jobs:
         # Limit the No. of API calls in one run default value is 30.
         operations-per-run: 1000
         # Prevent to remove stale label when PRs or issues are updated.
-        remove-stale-when-updated: false
+        remove-stale-when-updated: true
+        # List of labels to remove when issues/PRs unstale. 
+        labels-to-remove-when-unstale: 'stat:awaiting response'
         # comment on issue if not active for more then 7 days.
         stale-issue-message: 'This issue has been marked stale because it has no recent activity since 7 days. It will be closed if no further activity occurs. Thank you.'
         # comment on PR if not active for more then 14 days.


### PR DESCRIPTION
Remove the label "stat:awaiting response", when issue/PR unstale.