### PR TITLE
docs(api_rest.md): JSON key of regress/classify response is results instead of result

### DIFF
--- a/tensorflow_serving/g3doc/api_rest.md
+++ b/tensorflow_serving/g3doc/api_rest.md
@@ -127,7 +127,7 @@ follows:
 
 ```javascript
 {
-  "result": [
+  "results": [
     // List of class label/score pairs for first Example (in request)
     [ [<label1>, <score1>], [<label2>, <score2>], ... ],
 
@@ -148,7 +148,7 @@ follows:
 ```javascript
 {
   // One regression value for each example in the request in the same order.
-  "result": [ <value1>, <value2>, <value3>, ...]
+  "results": [ <value1>, <value2>, <value3>, ...]
 }
 ```
 


### PR DESCRIPTION
I thought the JSON key of regress and classify response is  `results`, not `result`.

When I follow Example section of https://www.tensorflow.org/tfx/serving/api_rest, I got the following response which the key is `results`, not `result` as described in website. Also, I tried the classify request, and found it return the label/score pairs with the `results` key.

```json
{
    "results": [3.5, 4.0]
}
```

It seems the response key is defined `results` here.

https://github.com/tensorflow/serving/blob/ebb71bfc52c4ac52f0061f356f9f81d919b5e841/tensorflow_serving/util/json_tensor.cc#L82

Sorry if I misunderstood. In case of this is my misunderstanding, I'll close this PR.