### PR TITLE
Fix ignoring git branch in Dockerfile.devel and Dockerfile.devel-gpu

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -93,7 +93,9 @@ RUN mkdir /bazel && \
 
 # Download TF Serving sources (optionally at specific commit).
 WORKDIR /tensorflow-serving
-RUN curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
+RUN git clone --single-branch --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving /tensorflow-serving && \
+    cd /tensorflow-serving && \
+    git reset --hard ${TF_SERVING_VERSION_GIT_COMMIT}
 
 FROM base_build as binary_build
 # Build, and install TensorFlow Serving

--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -30,7 +30,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download TF Serving sources (optionally at specific commit).
 WORKDIR /tensorflow-serving
-RUN curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
+RUN git clone --single-branch --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving /tensorflow-serving && \
+    cd /tensorflow-serving && \
+    git reset --hard ${TF_SERVING_VERSION_GIT_COMMIT}
 
 RUN /tensorflow-serving/tensorflow_serving/tools/docker/setup.sources.sh
 


### PR DESCRIPTION
The bazel argument TF_SERVING_VERSION_GIT_BRANCH was ignored in both dockerfiles, although it was correctly handled in .devel-mkl.

I just copied&pasted the same "git clone" lines from mkl. Now the command

`docker build --pull  -t $USER/tensorflow-serving-devel --build-arg TF_SERVING_VERSION_GIT_BRANCH="r2.18"  -f tensorflow_serving/tools/docker/Dockerfile.devel .`

uses the right branch.


Note: I realised it because there's a bug in tensorflow_serving/serving.bzl introduced two months ago by https://github.com/tensorflow/serving/commit/2c9e66b26e579258945bc3efe186a83e092485fd. I wanted to compile with r2.18 but the ARG in docker build didn't work and always used master.