### PR TITLE
Correct NaN typo in example JSON

### DIFF
--- a/tensorflow_serving/g3doc/api_rest.md
+++ b/tensorflow_serving/g3doc/api_rest.md
@@ -392,7 +392,7 @@ such values. This implies that requests like the following one are valid:
 {
   "example": [
     {
-      "sensor_readings": [ 1.0, -3.14, Nan, Infinity ]
+      "sensor_readings": [ 1.0, -3.14, NaN, Infinity ]
     }
   ]
 }


### PR DESCRIPTION
Based on the rest of the documentation and looking at the code, it
appears that this should be `NaN` and that `Nan` is invalid. This also
matches what the Python `json` library supports.
