### PR TITLE
Improve error message when model base path is missing

### DIFF
--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -256,9 +256,13 @@ absl::Status PollFileSystemForServable(
   // returns an empty list instead of erring if the base path isn't found.)
   absl::Status status = Env::Default()->FileExists(servable.base_path());
   if (!status.ok()) {
-    return errors::InvalidArgument(
-        "Could not find base path ", servable.base_path(), " for servable ",
-        servable.servable_name(), " with error ", status.ToString());
+    return errors::NotFound(
+      "Could not find base path ", servable.base_path(),
+      " for servable ", servable.servable_name(),
+      ". TensorFlow Serving expects the following directory structure:\n"
+      "  <base_path>/<version>/saved_model.pb\n"
+      "Where <version> is a numeric directory name (e.g. '1').\n"
+      "Underlying filesystem error: ", status.ToString());
   }
 
   if (servable.servable_version_policy().policy_choice_case() ==


### PR DESCRIPTION
This change improves the error message emitted when TensorFlow Serving
cannot find the configured model base path.

The new message explains the expected directory structure and helps users
diagnose common deployment and mounting issues more quickly.

Testing:
- Ran TensorFlow Serving with a valid model mount and verified normal operation.
- Removed the model base path at runtime to confirm the filesystem error path
  is exercised and the improved error message would be surfaced.
