### PR TITLE
Add tools/build.sh to automatically apply XLA/GCC compatibility patches

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Convenience wrapper to build TensorFlow Serving inside Docker.
+# Automatically applies known compatibility patches before building.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+function apply_compatibility_patches() {
+  echo "== Applying compatibility patches for XLA / GCC..."
+  
+  # Patch xla/shape.cc to fix noexcept mismatch with newer GCC versions
+  local shape_cc="${WORKSPACE_ROOT}/external/local_xla/xla/shape.cc"
+  if [[ -f "$shape_cc" ]]; then
+    if grep -q 'Shape::Shape(Shape&&) noexcept = default;' "$shape_cc"; then
+      sed -i 's/Shape::Shape(Shape&&) noexcept = default;/Shape::Shape(Shape&&) = default;/' "$shape_cc"
+      echo "   Patched: shape.cc (move ctor)"
+    fi
+    if grep -q 'Shape& Shape::operator=(Shape&&) noexcept = default;' "$shape_cc"; then
+      sed -i 's/Shape& Shape::operator=(Shape&&) noexcept = default;/Shape& Shape::operator=(Shape&&) = default;/' "$shape_cc"
+      echo "   Patched: shape.cc (move assign)"
+    fi
+  fi
+
+  # Also patch shape.h if it exists to keep declaration/definition consistent
+  local shape_h="${WORKSPACE_ROOT}/external/local_xla/xla/shape.h"
+  if [[ -f "$shape_h" ]]; then
+    sed -i 's/Shape(Shape&&) noexcept;/Shape(Shape&&);/' "$shape_h" 2>/dev/null || true
+    sed -i 's/operator=(Shape&&) noexcept;/operator=(Shape&&);/' "$shape_h" 2>/dev/null || true
+  fi
+
+  # Recursively find shape.cc if external/ not yet at expected path
+  find "${WORKSPACE_ROOT}" -path '*/xla/shape.cc' -not -path '*/.git/*' -print0 2>/dev/null | \
+    while IFS= read -r -d '' file; do
+      sed -i 's/Shape::Shape(Shape&&) noexcept = default;/Shape::Shape(Shape&&) = default;/' "$file" 2>/dev/null || true
+      sed -i 's/Shape& Shape::operator=(Shape&&) noexcept = default;/Shape& Shape::operator=(Shape&&) = default;/' "$file" 2>/dev/null || true
+    done
+}
+
+function usage() {
+  echo "Usage:"
+  echo "  $(basename $0) [bazel build flags] <target>"
+  echo ""
+  echo "Examples:"
+  echo "  $(basename $0) -c opt tensorflow_serving/model_servers:tensorflow_model_server"
+  echo "  $(basename $0) --config=nativeopt tensorflow_serving/..."
+  exit 1
+}
+
+# Ensure external/ deps are available before patching
+echo "== Fetching dependencies..."
+"${SCRIPT_DIR}/run_in_docker.sh" bazel fetch //tensorflow_serving/... 2>/dev/null || true
+
+# Apply patches in the local workspace
+apply_compatibility_patches
+
+# Forward everything to run_in_docker.sh for the actual build
+echo "== Starting build via run_in_docker.sh..."
+exec "${SCRIPT_DIR}/run_in_docker.sh" bazel build "$@"


### PR DESCRIPTION
## Description
This PR fixes #4108 by adding a `tools/build.sh` convenience wrapper that automatically applies known compatibility patches before invoking `run_in_docker.sh`.

### Problem
When building TF Serving from source with newer GCC versions (e.g., GCC 11/12/13), the build fails in `external/local_xla/xla/shape.cc` with:

error: function 'xla::Shape::Shape(xla::Shape&&)' defaulted on its redeclaration with an exception-specification that differs from the implicit exception-specification 'noexcept(false)'

This is caused by `noexcept` annotations on the move constructor/assignment that conflict with the implicit exception specification inferred by newer GCC/libstdc++.

### Solution
- Add `tools/build.sh` which:
  1. Runs `bazel fetch` inside Docker to ensure `external/` dependencies are present
  2. Applies `sed` patches to `xla/shape.cc` and `xla/shape.h` to remove the conflicting `noexcept` on move operations
  3. Forwards to `tools/run_in_docker.sh` for the actual build

### Usage
```bash
./tools/build.sh -c opt tensorflow_serving/model_servers:tensorflow_model_server

Why not patch run_in_docker.sh directly?

run_in_docker.sh is a generic command runner. Adding build-specific patches there would couple the general Docker launcher to a specific dependency workaround. A dedicated build.sh is cleaner and avoids surprising users who run non-build commands.
Fixes

Fixes #4108

### Commit Message

```bash
git add tools/build.sh
git commit -m "Add build.sh wrapper to fix XLA/GCC noexcept compatibility

Adds a dedicated build wrapper that automatically applies sed patches
for the XLA Shape move-ctor noexcept mismatch seen with GCC 11+.
This avoids modifying the generic run_in_docker.sh tool.

Fixes #4108"