### PR TITLE
Add bounds check in AddSingleValueAndAdvance to prevent OOB read from empty repeated fields

### DIFF
--- a/tensorflow_serving/util/json_tensor.cc
+++ b/tensorflow_serving/util/json_tensor.cc
@@ -888,6 +888,34 @@ bool IsNamedTensorBytes(const string& name, const TensorProto& tensor) {
 Status AddSingleValueAndAdvance(const TensorProto& tensor, bool string_as_bytes,
                                 RapidJsonWriter* writer, int* offset) {
   bool success = false;
+  // Check that the offset is within the bounds of the repeated field for
+  // this dtype. When --enable_serialization_as_tensor_content is used, the
+  // tensor data is stored in tensor_content and the typed repeated fields
+  // (float_val, int_val, etc.) remain empty, making this indexing OOB in
+  // release builds (RepeatedField::Get uses DCHECK, compiled out).
+  const int repeated_field_size = [&tensor]() -> int {
+    switch (tensor.dtype()) {
+      case DT_FLOAT:    return tensor.float_val_size();
+      case DT_DOUBLE:   return tensor.double_val_size();
+      case DT_INT32:
+      case DT_INT16:
+      case DT_INT8:
+      case DT_UINT8:    return tensor.int_val_size();
+      case DT_INT64:    return tensor.int64_val_size();
+      case DT_BOOL:     return tensor.bool_val_size();
+      case DT_UINT32:   return tensor.uint32_val_size();
+      case DT_UINT64:   return tensor.uint64_val_size();
+      case DT_STRING:   return tensor.string_val_size();
+      default:          return 0;
+    }
+  }();
+  if (*offset >= repeated_field_size) {
+    return errors::InvalidArgument(
+        "Tensor value index ", *offset,
+        " is out of bounds for dtype ", DataTypeString(tensor.dtype()),
+        " (repeated field size: ", repeated_field_size,
+        "). This can occur when tensor_content serialization is enabled");
+  }
   switch (tensor.dtype()) {
     case DT_FLOAT:
       success = WriteDecimal(writer, tensor.float_val(*offset));


### PR DESCRIPTION
## Problem

When `--enable_serialization_as_tensor_content` is set (a documented performance flag, model_servers/main.cc:312), output tensors are serialized via `AsProtoTensorContent` (predict_util.cc:185), placing data in `TensorProto.tensor_content` and leaving the typed repeated fields (`float_val`, `int_val`, etc.) **empty**.

The REST handler then serializes via `MakeJsonFromTensors` (http_rest_api_handler.cc:176) whose `AddSingleValueAndAdvance` (json_tensor.cc:888+) calls `tensor.float_val(*offset)` etc. unconditionally.

Protobuf's `RepeatedField::Get(index)` uses DCHECK — **compiled out in release builds**. On an empty repeated field:
- `Get(0)` reads uninitialized heap memory → written into the JSON response body (heap disclosure)
- Or dereferences null → SIGSEGV kills the server

## Fix

Add a bounds check before the switch statement: compute the repeated field's `size()` for the tensor's dtype and verify `*offset < size`. If out of bounds, return `InvalidArgument` with a descriptive message instead of indexing OOB.

## Verification

Reproduced in a C++ release build (protobuf 36, -O2 -DNDEBUG): a `TensorProto` with `tensor_content` set and `float_val` empty; calling `float_val(0)` (the exact indexing the REST writer performs) returns garbage from uninitialized memory. With this fix, the call returns an `InvalidArgument` error.

Reported via Google Bug Hunters (issue 553430318).